### PR TITLE
Added support for HMAC Message Authentication Code (MAC) digests

### DIFF
--- a/src/main/java/org/apache/commons/codec/digest/HmacAlgorithms.java
+++ b/src/main/java/org/apache/commons/codec/digest/HmacAlgorithms.java
@@ -20,12 +20,12 @@ package org.apache.commons.codec.digest;
 /**
  * Standard {@link HmacSHA512} algorithm names from the <cite>Java Cryptography
  * Architecture Standard Algorithm Name Documentation</cite>.
- * 
+ *
  * <p>
  * <strong> Note: Not all JCE implementations supports all in this enum listed
  * algorithms. </strong>
  * </p>
- * 
+ *
  * @see <a
  *      href="http://docs.oracle.com/javase/6/docs/technotes/guides/security/StandardNames.html">Java
  *      Cryptography Architecture Standard Algorithm Name Documentation</a>
@@ -34,53 +34,53 @@ package org.apache.commons.codec.digest;
  */
 public enum HmacAlgorithms {
 
-	/**
-	 * The HmacMD5 Message Authentication Code (MAC) algorithm specified in RFC
-	 * 2104 and RFC 1321.
-	 * 
-	 */
-	HMAC_MD5("HmacMD5"),
+    /**
+     * The HmacMD5 Message Authentication Code (MAC) algorithm specified in RFC
+     * 2104 and RFC 1321.
+     *
+     */
+    HMAC_MD5("HmacMD5"),
 
-	/**
-	 * The HmacSHA1 Message Authentication Code (MAC) algorithm specified in RFC
-	 * 2104 and FIPS PUB 180-2.
-	 */
-	HMAC_SHA_1("HmacSHA1"),
+    /**
+     * The HmacSHA1 Message Authentication Code (MAC) algorithm specified in RFC
+     * 2104 and FIPS PUB 180-2.
+     */
+    HMAC_SHA_1("HmacSHA1"),
 
-	/**
-	 * The HmacSHA256 Message Authentication Code (MAC) algorithm specified in
-	 * RFC 2104 and FIPS PUB 180-2.
-	 */
-	HMAC_SHA_256("HmacSHA256"),
+    /**
+     * The HmacSHA256 Message Authentication Code (MAC) algorithm specified in
+     * RFC 2104 and FIPS PUB 180-2.
+     */
+    HMAC_SHA_256("HmacSHA256"),
 
-	/**
-	 * The HmacSHA384 Message Authentication Code (MAC) algorithm specified in
-	 * RFC 2104 and FIPS PUB 180-2.
-	 */
-	HMAC_SHA_384("HmacSHA384"),
+    /**
+     * The HmacSHA384 Message Authentication Code (MAC) algorithm specified in
+     * RFC 2104 and FIPS PUB 180-2.
+     */
+    HMAC_SHA_384("HmacSHA384"),
 
-	/**
-	 * The HmacSHA512 Message Authentication Code (MAC) algorithm specified in
-	 * RFC 2104 and FIPS PUB 180-2.
-	 */
-	HMAC_SHA_512("HmacSHA512");
+    /**
+     * The HmacSHA512 Message Authentication Code (MAC) algorithm specified in
+     * RFC 2104 and FIPS PUB 180-2.
+     */
+    HMAC_SHA_512("HmacSHA512");
 
-	private final String algorithm;
+    private final String algorithm;
 
-	private HmacAlgorithms(final String algorithm) {
-		this.algorithm = algorithm;
-	}
+    private HmacAlgorithms(final String algorithm) {
+        this.algorithm = algorithm;
+    }
 
-	/**
-	 * The algorithm name 
-	 * 
-	 * @see <a href="http://docs.oracle.com/javase/6/docs/technotes/guides/security/SunProviders.html#SunJCEProvider">Java Cryptography Architecture
-     * Sun Providers Documentation</a>
-	 * @return The algorithm name ("HmacSHA512" for example)
-	 */
-	@Override
-	public String toString() {
-		return algorithm;
-	}
+    /**
+     * The algorithm name
+     *
+     * @see <a href="http://docs.oracle.com/javase/6/docs/technotes/guides/security/SunProviders.html#SunJCEProvider">
+     * Java Cryptography Architecture Sun Providers Documentation</a>
+     * @return The algorithm name ("HmacSHA512" for example)
+     */
+    @Override
+    public String toString() {
+        return algorithm;
+    }
 
 }

--- a/src/main/java/org/apache/commons/codec/digest/HmacUtils.java
+++ b/src/main/java/org/apache/commons/codec/digest/HmacUtils.java
@@ -31,848 +31,843 @@ import org.apache.commons.codec.binary.StringUtils;
 /**
  * Operations to simplify common {@link javax.crypto.Mac} tasks. This class is
  * immutable and thread-safe.
- * 
+ *
  * <p>
  * <strong> Note: Not all JCE implementations supports all in this enum listed
  * algorithms. In this a IllegalArgumentException is thrown. JRE's prior to 1.4
  * may need the JCE Standard Extension.</strong>
  * </p>
- * 
+ *
  * @version $Id$
  */
 public final class HmacUtils {
 
-	private static final int STREAM_BUFFER_LENGTH = 1024;
+    private static final int STREAM_BUFFER_LENGTH = 1024;
 
-	/**
-	 * Returns a initialized <code>Mac</code> for the given
-	 * <code>algorithm</code>.
-	 * 
-	 * @param algorithm
-	 *            the name of the algorithm requested. See <a href=
-	 *            "http://docs.oracle.com/javase/6/docs/technotes/guides/security/crypto/CryptoSpec.html#AppA"
-	 *            >Appendix A in the Java Cryptography Architecture Reference
-	 *            Guide</a> for information about standard algorithm names.
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @return A Mac instance initialized with the given key.
-	 * @see Mac#getInstance(String)
-	 * @see Mac#init(SecretKeySpec)
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static Mac getInitializedMac(HmacAlgorithms algorithm,
-			final byte[] key) {
-		return getInitializedMac(algorithm.toString(), key);
-	}
+    /**
+     * Returns a initialized <code>Mac</code> for the given
+     * <code>algorithm</code>.
+     *
+     * @param algorithm
+     *            the name of the algorithm requested. See <a href=
+     *            "http://docs.oracle.com/javase/6/docs/technotes/guides/security/crypto/CryptoSpec.html#AppA"
+     *            >Appendix A in the Java Cryptography Architecture Reference
+     *            Guide</a> for information about standard algorithm names.
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @return A Mac instance initialized with the given key.
+     * @see Mac#getInstance(String)
+     * @see Mac#init(SecretKeySpec)
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static Mac getInitializedMac(HmacAlgorithms algorithm,
+            final byte[] key) {
+        return getInitializedMac(algorithm.toString(), key);
+    }
 
-	/**
-	 * Returns a initialized <code>Mac</code> for the given
-	 * <code>algorithm</code>.
-	 * 
-	 * @param algorithm
-	 *            the name of the algorithm requested. See <a href=
-	 *            "http://docs.oracle.com/javase/6/docs/technotes/guides/security/crypto/CryptoSpec.html#AppA"
-	 *            >Appendix A in the Java Cryptography Architecture Reference
-	 *            Guide</a> for information about standard algorithm names.
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @return A Mac instance initialized with the given key.
-	 * @see Mac#getInstance(String)
-	 * @see Mac#init(SecretKeySpec)
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static Mac getInitializedMac(String algorithm, final byte[] key) {
+    /**
+     * Returns a initialized <code>Mac</code> for the given
+     * <code>algorithm</code>.
+     *
+     * @param algorithm
+     *            the name of the algorithm requested. See <a href=
+     *            "http://docs.oracle.com/javase/6/docs/technotes/guides/security/crypto/CryptoSpec.html#AppA"
+     *            >Appendix A in the Java Cryptography Architecture Reference
+     *            Guide</a> for information about standard algorithm names.
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @return A Mac instance initialized with the given key.
+     * @see Mac#getInstance(String)
+     * @see Mac#init(SecretKeySpec)
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static Mac getInitializedMac(String algorithm, final byte[] key) {
 
-		if (key == null) {
-			throw new IllegalArgumentException("Null Key");
-		}
+        if (key == null) {
+            throw new IllegalArgumentException("Null Key");
+        }
 
-		try {
-			SecretKeySpec keySpec = null;
+        if (key.length == 0) {
+            throw new IllegalArgumentException("Empty Key");
+        }
 
-			if (key.length == 0) {
-				// https://bugs.openjdk.java.net/browse/JDK-8020509
-				byte[] dummyKey = "dummy".getBytes();
-				keySpec = new SecretKeySpec(dummyKey, dummyKey.length, 0,
-						algorithm);
-			} else {
-				keySpec = new SecretKeySpec(key, algorithm);
-			}
+        try {
+            SecretKeySpec keySpec = new SecretKeySpec(key, algorithm);
+            Mac mac = Mac.getInstance(algorithm);
+            mac.init(keySpec);
+            return mac;
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalArgumentException(e);
+        } catch (InvalidKeyException e) {
+            //cannot happen
+            throw new IllegalArgumentException(e);
+        }
+    }
 
-			Mac mac = Mac.getInstance(algorithm);
-			mac.init(keySpec);
-			return mac;
-		} catch (NoSuchAlgorithmException e) {
-			throw new IllegalArgumentException(e);
-		} catch (InvalidKeyException e) {
-			throw new IllegalArgumentException(e);
-		}
-	}
+    /**
+     * Returns a initialized <code>Mac</code> for the HmacMD5 algorithm.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @return A Mac instance initialized with the given key.
+     * @see Mac#getInstance(String)
+     * @see Mac#init(SecretKeySpec)
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static Mac getHmacMd5(final byte[] key) {
+        return getInitializedMac(HmacAlgorithms.HMAC_MD5, key);
+    }
 
-	/**
-	 * Returns a initialized <code>Mac</code> for the HmacMD5 algorithm.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @return A Mac instance initialized with the given key.
-	 * @see Mac#getInstance(String)
-	 * @see Mac#init(SecretKeySpec)
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static Mac getHmacMd5(final byte[] key) {
-		return getInitializedMac(HmacAlgorithms.HMAC_MD5, key);
-	}
+    /**
+     * Returns a initialized <code>Mac</code> for the HmacSHA1 algorithm.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @return A Mac instance initialized with the given key.
+     * @see Mac#getInstance(String)
+     * @see Mac#init(SecretKeySpec)
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static Mac getHmacSha1(final byte[] key) {
+        return getInitializedMac(HmacAlgorithms.HMAC_SHA_1, key);
+    }
 
-	/**
-	 * Returns a initialized <code>Mac</code> for the HmacSHA1 algorithm.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @return A Mac instance initialized with the given key.
-	 * @see Mac#getInstance(String)
-	 * @see Mac#init(SecretKeySpec)
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static Mac getHmacSha1(final byte[] key) {
-		return getInitializedMac(HmacAlgorithms.HMAC_SHA_1, key);
-	}
+    /**
+     * Returns a initialized <code>Mac</code> for the HmacSHA256 algorithm.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @return A Mac instance initialized with the given key.
+     * @see Mac#getInstance(String)
+     * @see Mac#init(SecretKeySpec)
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static Mac getHmacSha256(final byte[] key) {
+        return getInitializedMac(HmacAlgorithms.HMAC_SHA_256, key);
+    }
 
-	/**
-	 * Returns a initialized <code>Mac</code> for the HmacSHA256 algorithm.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @return A Mac instance initialized with the given key.
-	 * @see Mac#getInstance(String)
-	 * @see Mac#init(SecretKeySpec)
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static Mac getHmacSha256(final byte[] key) {
-		return getInitializedMac(HmacAlgorithms.HMAC_SHA_256, key);
-	}
+    /**
+     * Returns a initialized <code>Mac</code> for the HmacSHA384 algorithm.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @return A Mac instance initialized with the given key.
+     * @see Mac#getInstance(String)
+     * @see Mac#init(SecretKeySpec)
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static Mac getHmacSha384(final byte[] key) {
+        return getInitializedMac(HmacAlgorithms.HMAC_SHA_384, key);
+    }
 
-	/**
-	 * Returns a initialized <code>Mac</code> for the HmacSHA384 algorithm.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @return A Mac instance initialized with the given key.
-	 * @see Mac#getInstance(String)
-	 * @see Mac#init(SecretKeySpec)
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static Mac getHmacSha384(final byte[] key) {
-		return getInitializedMac(HmacAlgorithms.HMAC_SHA_384, key);
-	}
+    /**
+     * Returns a initialized <code>Mac</code> for the HmacSHA512 algorithm.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @return A Mac instance initialized with the given key.
+     * @see Mac#getInstance(String)
+     * @see Mac#init(SecretKeySpec)
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static Mac getHmacSha512(final byte[] key) {
+        return getInitializedMac(HmacAlgorithms.HMAC_SHA_512, key);
+    }
 
-	/**
-	 * Returns a initialized <code>Mac</code> for the HmacSHA512 algorithm.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @return A Mac instance initialized with the given key.
-	 * @see Mac#getInstance(String)
-	 * @see Mac#init(SecretKeySpec)
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static Mac getHmacSha512(final byte[] key) {
-		return getInitializedMac(HmacAlgorithms.HMAC_SHA_512, key);
-	}
+    // hmacMd5
 
-	// hmacMd5
+    /**
+     * Returns a HmacMD5 Message Authentication Code (MAC) for the given key and
+     * value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest (maybe empty or null)
+     * @return HmacMD5 MAC for the given key and value
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static byte[] hmacMd5(final String key, final String valueToDigest) {
+        return hmacMd5(StringUtils.getBytesUtf8(key),
+                StringUtils.getBytesUtf8(valueToDigest));
+    }
 
-	/**
-	 * Returns a HmacMD5 Message Authentication Code (MAC) for the given key and
-	 * value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest (maybe empty or null)
-	 * @return HmacMD5 MAC for the given key and value
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static byte[] hmacMd5(final String key, final String valueToDigest) {
-		return hmacMd5(StringUtils.getBytesUtf8(key),
-				StringUtils.getBytesUtf8(valueToDigest));
-	}
+    /**
+     * Returns a HmacMD5 Message Authentication Code (MAC) for the given key and
+     * value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest (maybe empty or null)
+     * @return HmacMD5 MAC for the given key and value
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static byte[] hmacMd5(final byte[] key, final byte[] valueToDigest) {
+        try {
+            return getHmacMd5(key).doFinal(valueToDigest);
+        } catch (IllegalStateException e) {
+            // cannot happen
+            throw new IllegalArgumentException(e);
+        }
+    }
 
-	/**
-	 * Returns a HmacMD5 Message Authentication Code (MAC) for the given key and
-	 * value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest (maybe empty or null)
-	 * @return HmacMD5 MAC for the given key and value
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static byte[] hmacMd5(final byte[] key, final byte[] valueToDigest) {
-		try {
-			return getHmacMd5(key).doFinal(valueToDigest);
-		} catch (IllegalStateException e) {
-			// cannot happen
-			throw new IllegalArgumentException(e);
-		}
-	}
+    /**
+     * Returns a HmacMD5 Message Authentication Code (MAC) for the given key and
+     * value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest
+     *            <p>
+     *            The Inputstream must not be null and will not be closed
+     *            </p>
+     * @return HmacMD5 MAC for the given key and value
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static byte[] hmacMd5(final byte[] key,
+            final InputStream valueToDigest) throws IOException {
+        return updateHmac(getHmacMd5(key), valueToDigest).doFinal();
+    }
 
-	/**
-	 * Returns a HmacMD5 Message Authentication Code (MAC) for the given key and
-	 * value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest
-	 *            <p>
-	 *            The Inputstream must not be null and will not be closed
-	 *            </p>
-	 * @return HmacMD5 MAC for the given key and value
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static byte[] hmacMd5(final byte[] key,
-			final InputStream valueToDigest) throws IOException {
-		return updateHmac(getHmacMd5(key), valueToDigest).doFinal();
-	}
+    /**
+     * Returns a HmacMD5 Message Authentication Code (MAC) as a hex string
+     * (lowercase) for the given key and value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest (maybe empty or null)
+     * @return HmacMD5 MAC for the given key and value as a hex string
+     *         (lowercase)
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static String hmacMd5Hex(final byte[] key, final byte[] valueToDigest) {
+        return Hex.encodeHexString(hmacMd5(key, valueToDigest));
+    }
 
-	/**
-	 * Returns a HmacMD5 Message Authentication Code (MAC) as a hex string
-	 * (lowercase) for the given key and value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest (maybe empty or null)
-	 * @return HmacMD5 MAC for the given key and value as a hex string
-	 *         (lowercase)
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static String hmacMd5Hex(final byte[] key, final byte[] valueToDigest) {
-		return Hex.encodeHexString(hmacMd5(key, valueToDigest));
-	}
+    /**
+     * Returns a HmacMD5 Message Authentication Code (MAC) as a hex string
+     * (lowercase) for the given key and value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest (maybe empty or null)
+     * @return HmacMD5 MAC for the given key and value as a hex string
+     *         (lowercase)
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static String hmacMd5Hex(final String key, final String valueToDigest) {
+        return Hex.encodeHexString(hmacMd5(key, valueToDigest));
+    }
 
-	/**
-	 * Returns a HmacMD5 Message Authentication Code (MAC) as a hex string
-	 * (lowercase) for the given key and value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest (maybe empty or null)
-	 * @return HmacMD5 MAC for the given key and value as a hex string
-	 *         (lowercase)
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static String hmacMd5Hex(final String key, final String valueToDigest) {
-		return Hex.encodeHexString(hmacMd5(key, valueToDigest));
-	}
+    /**
+     * Returns a HmacMD5 Message Authentication Code (MAC) as a hex string
+     * (lowercase) for the given key and value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest
+     *            <p>
+     *            The Inputstream must not be null and will not be closed
+     *            </p>
+     * @return HmacMD5 MAC for the given key and value as a hex string
+     *         (lowercase)
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static String hmacMd5Hex(final byte[] key,
+            final InputStream valueToDigest) throws IOException {
+        return Hex.encodeHexString(hmacMd5(key, valueToDigest));
+    }
 
-	/**
-	 * Returns a HmacMD5 Message Authentication Code (MAC) as a hex string
-	 * (lowercase) for the given key and value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest
-	 *            <p>
-	 *            The Inputstream must not be null and will not be closed
-	 *            </p>
-	 * @return HmacMD5 MAC for the given key and value as a hex string
-	 *         (lowercase)
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static String hmacMd5Hex(final byte[] key,
-			final InputStream valueToDigest) throws IOException {
-		return Hex.encodeHexString(hmacMd5(key, valueToDigest));
-	}
+    // hmacSha1
 
-	// hmacSha1
+    /**
+     * Returns a HmacSHA1 Message Authentication Code (MAC) for the given key
+     * and value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest (maybe empty or null)
+     * @return HmacSHA1 MAC for the given key and value
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static byte[] hmacSha1(final byte[] key, final byte[] valueToDigest) {
+        try {
+            return getHmacSha1(key).doFinal(valueToDigest);
+        } catch (IllegalStateException e) {
+            // cannot happen
+            throw new IllegalArgumentException(e);
+        }
+    }
 
-	/**
-	 * Returns a HmacSHA1 Message Authentication Code (MAC) for the given key
-	 * and value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest (maybe empty or null)
-	 * @return HmacSHA1 MAC for the given key and value
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static byte[] hmacSha1(final byte[] key, final byte[] valueToDigest) {
-		try {
-			return getHmacSha1(key).doFinal(valueToDigest);
-		} catch (IllegalStateException e) {
-			// cannot happen
-			throw new IllegalArgumentException(e);
-		}
-	}
+    /**
+     * Returns a HmacSHA1 Message Authentication Code (MAC) for the given key
+     * and value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest (maybe empty or null)
+     * @return HmacSHA1 MAC for the given key and value
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static byte[] hmacSha1(final String key, final String valueToDigest) {
+        return hmacSha1(StringUtils.getBytesUtf8(key),
+                StringUtils.getBytesUtf8(valueToDigest));
+    }
 
-	/**
-	 * Returns a HmacSHA1 Message Authentication Code (MAC) for the given key
-	 * and value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest (maybe empty or null)
-	 * @return HmacSHA1 MAC for the given key and value
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static byte[] hmacSha1(final String key, final String valueToDigest) {
-		return hmacSha1(StringUtils.getBytesUtf8(key),
-				StringUtils.getBytesUtf8(valueToDigest));
-	}
+    /**
+     * Returns a HmacSHA1 Message Authentication Code (MAC) for the given key
+     * and value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest
+     *            <p>
+     *            The Inputstream must not be null and will not be closed
+     *            </p>
+     * @return HmacSHA1 MAC for the given key and value
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static byte[] hmacSha1(final byte[] key,
+            final InputStream valueToDigest) throws IOException {
+        return updateHmac(getHmacSha1(key), valueToDigest).doFinal();
+    }
 
-	/**
-	 * Returns a HmacSHA1 Message Authentication Code (MAC) for the given key
-	 * and value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest
-	 *            <p>
-	 *            The Inputstream must not be null and will not be closed
-	 *            </p>
-	 * @return HmacSHA1 MAC for the given key and value
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static byte[] hmacSha1(final byte[] key,
-			final InputStream valueToDigest) throws IOException {
-		return updateHmac(getHmacSha1(key), valueToDigest).doFinal();
-	}
+    /**
+     * Returns a HmacSHA1 Message Authentication Code (MAC) as hex string
+     * (lowercase) for the given key and value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest (maybe empty or null)
+     * @return HmacSHA1 MAC for the given key and value as hex string
+     *         (lowercase)
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static String hmacSha1Hex(final byte[] key,
+            final byte[] valueToDigest) {
+        return Hex.encodeHexString(hmacSha1(key, valueToDigest));
+    }
 
-	/**
-	 * Returns a HmacSHA1 Message Authentication Code (MAC) as hex string
-	 * (lowercase) for the given key and value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest (maybe empty or null)
-	 * @return HmacSHA1 MAC for the given key and value as hex string
-	 *         (lowercase)
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static String hmacSha1Hex(final byte[] key,
-			final byte[] valueToDigest) {
-		return Hex.encodeHexString(hmacSha1(key, valueToDigest));
-	}
+    /**
+     * Returns a HmacSHA1 Message Authentication Code (MAC) as hex string
+     * (lowercase) for the given key and value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest (maybe empty or null)
+     * @return HmacSHA1 MAC for the given key and value as hex string
+     *         (lowercase)
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static String hmacSha1Hex(final String key,
+            final String valueToDigest) {
+        return Hex.encodeHexString(hmacSha1(key, valueToDigest));
+    }
 
-	/**
-	 * Returns a HmacSHA1 Message Authentication Code (MAC) as hex string
-	 * (lowercase) for the given key and value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest (maybe empty or null)
-	 * @return HmacSHA1 MAC for the given key and value as hex string
-	 *         (lowercase)
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static String hmacSha1Hex(final String key,
-			final String valueToDigest) {
-		return Hex.encodeHexString(hmacSha1(key, valueToDigest));
-	}
+    /**
+     * Returns a HmacSHA1 Message Authentication Code (MAC) as hex string
+     * (lowercase) for the given key and value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest
+     *            <p>
+     *            The Inputstream must not be null and will not be closed
+     *            </p>
+     * @return HmacSHA1 MAC for the given key and value as hex string
+     *         (lowercase)
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static String hmacSha1Hex(final byte[] key,
+            final InputStream valueToDigest) throws IOException {
+        return Hex.encodeHexString(hmacSha1(key, valueToDigest));
+    }
 
-	/**
-	 * Returns a HmacSHA1 Message Authentication Code (MAC) as hex string
-	 * (lowercase) for the given key and value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest
-	 *            <p>
-	 *            The Inputstream must not be null and will not be closed
-	 *            </p>
-	 * @return HmacSHA1 MAC for the given key and value as hex string
-	 *         (lowercase)
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static String hmacSha1Hex(final byte[] key,
-			final InputStream valueToDigest) throws IOException {
-		return Hex.encodeHexString(hmacSha1(key, valueToDigest));
-	}
+    // hmacSha256
 
-	// hmacSha256
+    /**
+     * Returns a HmacSHA256 Message Authentication Code (MAC) for the given key
+     * and value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest (maybe empty or null)
+     * @return HmacSHA256 MAC for the given key and value
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static byte[] hmacSha256(final byte[] key, final byte[] valueToDigest) {
+        try {
+            return getHmacSha256(key).doFinal(valueToDigest);
+        } catch (IllegalStateException e) {
+            // cannot happen
+            throw new IllegalArgumentException(e);
+        }
+    }
 
-	/**
-	 * Returns a HmacSHA256 Message Authentication Code (MAC) for the given key
-	 * and value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest (maybe empty or null)
-	 * @return HmacSHA256 MAC for the given key and value
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static byte[] hmacSha256(final byte[] key, final byte[] valueToDigest) {
-		try {
-			return getHmacSha256(key).doFinal(valueToDigest);
-		} catch (IllegalStateException e) {
-			// cannot happen
-			throw new IllegalArgumentException(e);
-		}
-	}
+    /**
+     * Returns a HmacSHA256 Message Authentication Code (MAC) for the given key
+     * and value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest (maybe empty or null)
+     * @return HmacSHA256 MAC for the given key and value
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static byte[] hmacSha256(final String key, final String valueToDigest) {
+        return hmacSha256(StringUtils.getBytesUtf8(key),
+                StringUtils.getBytesUtf8(valueToDigest));
+    }
 
-	/**
-	 * Returns a HmacSHA256 Message Authentication Code (MAC) for the given key
-	 * and value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest (maybe empty or null)
-	 * @return HmacSHA256 MAC for the given key and value
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static byte[] hmacSha256(final String key, final String valueToDigest) {
-		return hmacSha256(StringUtils.getBytesUtf8(key),
-				StringUtils.getBytesUtf8(valueToDigest));
-	}
+    /**
+     * Returns a HmacSHA256 Message Authentication Code (MAC) for the given key
+     * and value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest
+     *            <p>
+     *            The Inputstream must not be null and will not be closed
+     *            </p>
+     * @return HmacSHA256 MAC for the given key and value
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static byte[] hmacSha256(final byte[] key,
+            final InputStream valueToDigest) throws IOException {
+        return updateHmac(getHmacSha256(key), valueToDigest).doFinal();
+    }
 
-	/**
-	 * Returns a HmacSHA256 Message Authentication Code (MAC) for the given key
-	 * and value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest
-	 *            <p>
-	 *            The Inputstream must not be null and will not be closed
-	 *            </p>
-	 * @return HmacSHA256 MAC for the given key and value
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static byte[] hmacSha256(final byte[] key,
-			final InputStream valueToDigest) throws IOException {
-		return updateHmac(getHmacSha256(key), valueToDigest).doFinal();
-	}
+    /**
+     * Returns a HmacSHA256 Message Authentication Code (MAC) as hex string
+     * (lowercase) for the given key and value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest (maybe empty or null)
+     * @return HmacSHA256 MAC for the given key and value as hex string
+     *         (lowercase)
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static String hmacSha256Hex(final byte[] key,
+            final byte[] valueToDigest) {
+        return Hex.encodeHexString(hmacSha256(key, valueToDigest));
+    }
 
-	/**
-	 * Returns a HmacSHA256 Message Authentication Code (MAC) as hex string
-	 * (lowercase) for the given key and value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest (maybe empty or null)
-	 * @return HmacSHA256 MAC for the given key and value as hex string
-	 *         (lowercase)
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static String hmacSha256Hex(final byte[] key,
-			final byte[] valueToDigest) {
-		return Hex.encodeHexString(hmacSha256(key, valueToDigest));
-	}
+    /**
+     * Returns a HmacSHA256 Message Authentication Code (MAC) as hex string
+     * (lowercase) for the given key and value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest (maybe empty or null)
+     * @return HmacSHA256 MAC for the given key and value as hex string
+     *         (lowercase)
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static String hmacSha256Hex(final String key,
+            final String valueToDigest) {
+        return Hex.encodeHexString(hmacSha256(key, valueToDigest));
+    }
 
-	/**
-	 * Returns a HmacSHA256 Message Authentication Code (MAC) as hex string
-	 * (lowercase) for the given key and value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest (maybe empty or null)
-	 * @return HmacSHA256 MAC for the given key and value as hex string
-	 *         (lowercase)
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static String hmacSha256Hex(final String key,
-			final String valueToDigest) {
-		return Hex.encodeHexString(hmacSha256(key, valueToDigest));
-	}
+    /**
+     * Returns a HmacSHA256 Message Authentication Code (MAC) as hex string
+     * (lowercase) for the given key and value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest
+     *            <p>
+     *            The Inputstream must not be null and will not be closed
+     *            </p>
+     * @return HmacSHA256 MAC for the given key and value as hex string
+     *         (lowercase)
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static String hmacSha256Hex(final byte[] key,
+            final InputStream valueToDigest) throws IOException {
+        return Hex.encodeHexString(hmacSha256(key, valueToDigest));
+    }
 
-	/**
-	 * Returns a HmacSHA256 Message Authentication Code (MAC) as hex string
-	 * (lowercase) for the given key and value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest
-	 *            <p>
-	 *            The Inputstream must not be null and will not be closed
-	 *            </p>
-	 * @return HmacSHA256 MAC for the given key and value as hex string
-	 *         (lowercase)
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static String hmacSha256Hex(final byte[] key,
-			final InputStream valueToDigest) throws IOException {
-		return Hex.encodeHexString(hmacSha256(key, valueToDigest));
-	}
+    // hmacSha384
 
-	// hmacSha384
+    /**
+     * Returns a HmacSHA384 Message Authentication Code (MAC) for the given key
+     * and value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest (maybe empty or null)
+     * @return HmacSHA384 MAC for the given key and value
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static byte[] hmacSha384(final byte[] key, final byte[] valueToDigest) {
+        try {
+            return getHmacSha384(key).doFinal(valueToDigest);
+        } catch (IllegalStateException e) {
+            // cannot happen
+            throw new IllegalArgumentException(e);
+        }
+    }
 
-	/**
-	 * Returns a HmacSHA384 Message Authentication Code (MAC) for the given key
-	 * and value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest (maybe empty or null)
-	 * @return HmacSHA384 MAC for the given key and value
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static byte[] hmacSha384(final byte[] key, final byte[] valueToDigest) {
-		try {
-			return getHmacSha384(key).doFinal(valueToDigest);
-		} catch (IllegalStateException e) {
-			// cannot happen
-			throw new IllegalArgumentException(e);
-		}
-	}
+    /**
+     * Returns a HmacSHA384 Message Authentication Code (MAC) for the given key
+     * and value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest (maybe empty or null)
+     * @return HmacSHA384 MAC for the given key and value
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static byte[] hmacSha384(final String key, final String valueToDigest) {
+        return hmacSha384(StringUtils.getBytesUtf8(key),
+                StringUtils.getBytesUtf8(valueToDigest));
+    }
 
-	/**
-	 * Returns a HmacSHA384 Message Authentication Code (MAC) for the given key
-	 * and value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest (maybe empty or null)
-	 * @return HmacSHA384 MAC for the given key and value
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static byte[] hmacSha384(final String key, final String valueToDigest) {
-		return hmacSha384(StringUtils.getBytesUtf8(key),
-				StringUtils.getBytesUtf8(valueToDigest));
-	}
+    /**
+     * Returns a HmacSHA384 Message Authentication Code (MAC) for the given key
+     * and value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest
+     *            <p>
+     *            The Inputstream must not be null and will not be closed
+     *            </p>
+     * @return HmacSHA384 MAC for the given key and value
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static byte[] hmacSha384(final byte[] key,
+            final InputStream valueToDigest) throws IOException {
+        return updateHmac(getHmacSha384(key), valueToDigest).doFinal();
+    }
 
-	/**
-	 * Returns a HmacSHA384 Message Authentication Code (MAC) for the given key
-	 * and value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest
-	 *            <p>
-	 *            The Inputstream must not be null and will not be closed
-	 *            </p>
-	 * @return HmacSHA384 MAC for the given key and value
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static byte[] hmacSha384(final byte[] key,
-			final InputStream valueToDigest) throws IOException {
-		return updateHmac(getHmacSha384(key), valueToDigest).doFinal();
-	}
+    /**
+     * Returns a HmacSHA384 Message Authentication Code (MAC) as hex string
+     * (lowercase) for the given key and value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest (maybe empty or null)
+     * @return HmacSHA384 MAC for the given key and value as hex string
+     *         (lowercase)
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static String hmacSha384Hex(final byte[] key,
+            final byte[] valueToDigest) {
+        return Hex.encodeHexString(hmacSha384(key, valueToDigest));
+    }
 
-	/**
-	 * Returns a HmacSHA384 Message Authentication Code (MAC) as hex string
-	 * (lowercase) for the given key and value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest (maybe empty or null)
-	 * @return HmacSHA384 MAC for the given key and value as hex string
-	 *         (lowercase)
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static String hmacSha384Hex(final byte[] key,
-			final byte[] valueToDigest) {
-		return Hex.encodeHexString(hmacSha384(key, valueToDigest));
-	}
+    /**
+     * Returns a HmacSHA384 Message Authentication Code (MAC) as hex string
+     * (lowercase) for the given key and value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest (maybe empty or null)
+     * @return HmacSHA384 MAC for the given key and value as hex string
+     *         (lowercase)
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static String hmacSha384Hex(final String key,
+            final String valueToDigest) {
+        return Hex.encodeHexString(hmacSha384(key, valueToDigest));
+    }
 
-	/**
-	 * Returns a HmacSHA384 Message Authentication Code (MAC) as hex string
-	 * (lowercase) for the given key and value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest (maybe empty or null)
-	 * @return HmacSHA384 MAC for the given key and value as hex string
-	 *         (lowercase)
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static String hmacSha384Hex(final String key,
-			final String valueToDigest) {
-		return Hex.encodeHexString(hmacSha384(key, valueToDigest));
-	}
+    /**
+     * Returns a HmacSHA384 Message Authentication Code (MAC) as hex string
+     * (lowercase) for the given key and value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest
+     *            <p>
+     *            The Inputstream must not be null and will not be closed
+     *            </p>
+     * @return HmacSHA384 MAC for the given key and value as hex string
+     *         (lowercase)
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static String hmacSha384Hex(final byte[] key,
+            final InputStream valueToDigest) throws IOException {
+        return Hex.encodeHexString(hmacSha384(key, valueToDigest));
+    }
 
-	/**
-	 * Returns a HmacSHA384 Message Authentication Code (MAC) as hex string
-	 * (lowercase) for the given key and value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest
-	 *            <p>
-	 *            The Inputstream must not be null and will not be closed
-	 *            </p>
-	 * @return HmacSHA384 MAC for the given key and value as hex string
-	 *         (lowercase)
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static String hmacSha384Hex(final byte[] key,
-			final InputStream valueToDigest) throws IOException {
-		return Hex.encodeHexString(hmacSha384(key, valueToDigest));
-	}
+    // hmacSha512
 
-	// hmacSha512
+    /**
+     * Returns a HmacSHA512 Message Authentication Code (MAC) for the given key
+     * and value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest (maybe empty or null)
+     * @return HmacSHA512 MAC for the given key and value
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static byte[] hmacSha512(final byte[] key, final byte[] valueToDigest) {
+        try {
+            return getHmacSha512(key).doFinal(valueToDigest);
+        } catch (IllegalStateException e) {
+            // cannot happen
+            throw new IllegalArgumentException(e);
+        }
+    }
 
-	/**
-	 * Returns a HmacSHA512 Message Authentication Code (MAC) for the given key
-	 * and value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest (maybe empty or null)
-	 * @return HmacSHA512 MAC for the given key and value
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static byte[] hmacSha512(final byte[] key, final byte[] valueToDigest) {
-		try {
-			return getHmacSha512(key).doFinal(valueToDigest);
-		} catch (IllegalStateException e) {
-			// cannot happen
-			throw new IllegalArgumentException(e);
-		}
-	}
+    /**
+     * Returns a HmacSHA512 Message Authentication Code (MAC) for the given key
+     * and value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest (maybe empty or null)
+     * @return HmacSHA512 MAC for the given key and value
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static byte[] hmacSha512(final String key, final String valueToDigest) {
+        return hmacSha512(StringUtils.getBytesUtf8(key),
+                StringUtils.getBytesUtf8(valueToDigest));
+    }
 
-	/**
-	 * Returns a HmacSHA512 Message Authentication Code (MAC) for the given key
-	 * and value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest (maybe empty or null)
-	 * @return HmacSHA512 MAC for the given key and value
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static byte[] hmacSha512(final String key, final String valueToDigest) {
-		return hmacSha512(StringUtils.getBytesUtf8(key),
-				StringUtils.getBytesUtf8(valueToDigest));
-	}
+    /**
+     * Returns a HmacSHA512 Message Authentication Code (MAC) for the given key
+     * and value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest
+     *            <p>
+     *            The Inputstream must not be null and will not be closed
+     *            </p>
+     * @return HmacSHA512 MAC for the given key and value
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static byte[] hmacSha512(final byte[] key,
+            final InputStream valueToDigest) throws IOException {
+        return updateHmac(getHmacSha512(key), valueToDigest).doFinal();
+    }
 
-	/**
-	 * Returns a HmacSHA512 Message Authentication Code (MAC) for the given key
-	 * and value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest
-	 *            <p>
-	 *            The Inputstream must not be null and will not be closed
-	 *            </p>
-	 * @return HmacSHA512 MAC for the given key and value
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static byte[] hmacSha512(final byte[] key,
-			final InputStream valueToDigest) throws IOException {
-		return updateHmac(getHmacSha512(key), valueToDigest).doFinal();
-	}
+    /**
+     * Returns a HmacSHA512 Message Authentication Code (MAC) as hex string
+     * (lowercase) for the given key and value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest (maybe empty or null)
+     * @return HmacSHA512 MAC for the given key and value as hex string
+     *         (lowercase)
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static String hmacSha512Hex(final byte[] key,
+            final byte[] valueToDigest) {
+        return Hex.encodeHexString(hmacSha512(key, valueToDigest));
+    }
 
-	/**
-	 * Returns a HmacSHA512 Message Authentication Code (MAC) as hex string
-	 * (lowercase) for the given key and value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest (maybe empty or null)
-	 * @return HmacSHA512 MAC for the given key and value as hex string
-	 *         (lowercase)
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static String hmacSha512Hex(final byte[] key,
-			final byte[] valueToDigest) {
-		return Hex.encodeHexString(hmacSha512(key, valueToDigest));
-	}
+    /**
+     * Returns a HmacSHA512 Message Authentication Code (MAC) as hex string
+     * (lowercase) for the given key and value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest (maybe empty or null)
+     * @return HmacSHA512 MAC for the given key and value as hex string
+     *         (lowercase)
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static String hmacSha512Hex(final String key,
+            final String valueToDigest) {
+        return Hex.encodeHexString(hmacSha512(key, valueToDigest));
+    }
 
-	/**
-	 * Returns a HmacSHA512 Message Authentication Code (MAC) as hex string
-	 * (lowercase) for the given key and value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest (maybe empty or null)
-	 * @return HmacSHA512 MAC for the given key and value as hex string
-	 *         (lowercase)
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static String hmacSha512Hex(final String key,
-			final String valueToDigest) {
-		return Hex.encodeHexString(hmacSha512(key, valueToDigest));
-	}
+    /**
+     * Returns a HmacSHA512 Message Authentication Code (MAC) as hex string
+     * (lowercase) for the given key and value.
+     *
+     * @param key
+     *            They key for the keyed digest (must not be null or empty)
+     * @param valueToDigest
+     *            The value (data) which should to digest
+     *            <p>
+     *            The Inputstream must not be null and will not be closed
+     *            </p>
+     * @return HmacSHA512 MAC for the given key and value as hex string
+     *         (lowercase)
+     * @throws IllegalArgumentException
+     *             when a {@link NoSuchAlgorithmException} is caught or key is
+     *             null or empty or key is invalid.
+     */
+    public static String hmacSha512Hex(final byte[] key,
+            final InputStream valueToDigest) throws IOException {
+        return Hex.encodeHexString(hmacSha512(key, valueToDigest));
+    }
 
-	/**
-	 * Returns a HmacSHA512 Message Authentication Code (MAC) as hex string
-	 * (lowercase) for the given key and value.
-	 * 
-	 * @param key
-	 *            They key for the keyed digest (must not be null)
-	 * @param valueToDigest
-	 *            The value (data) which should to digest
-	 *            <p>
-	 *            The Inputstream must not be null and will not be closed
-	 *            </p>
-	 * @return HmacSHA512 MAC for the given key and value as hex string
-	 *         (lowercase)
-	 * @throws IllegalArgumentException
-	 *             when a {@link NoSuchAlgorithmException} is caught or key is
-	 *             null or key is invalid.
-	 */
-	public static String hmacSha512Hex(final byte[] key,
-			final InputStream valueToDigest) throws IOException {
-		return Hex.encodeHexString(hmacSha512(key, valueToDigest));
-	}
+    // update
 
-	// update
+    /**
+     * Updates the given {@link Mac}. This generates a digest for valueToDigest
+     * and the key the Mac was initialized
+     *
+     * @param mac
+     *            the initialized {@link Mac} to update
+     * @param valueToDigest
+     *            the value to update the {@link Mac} with (maybe null or empty)
+     * @return the updated {@link Mac}
+     * @throws IllegalStateException
+     *             if the Mac was not initialized
+     * @since 1.x
+     */
+    public static Mac updateHmac(final Mac mac, final byte[] valueToDigest) {
+        mac.reset();
+        mac.update(valueToDigest);
+        return mac;
+    }
 
-	/**
-	 * Updates the given {@link Mac}. This generates a digest for valueToDigest
-	 * and the key the Mac was initialized
-	 * 
-	 * @param mac
-	 *            the initialized {@link Mac} to update
-	 * @param valueToDigest
-	 *            the value to update the {@link Mac} with (maybe null or empty)
-	 * @return the updated {@link Mac}
-	 * @throws IllegalStateException
-	 *             if the Mac was not initialized
-	 * @since 1.x
-	 */
-	public static Mac updateHmac(final Mac mac, final byte[] valueToDigest) {
-		mac.reset();
-		mac.update(valueToDigest);
-		return mac;
-	}
+    /**
+     * Updates the given {@link Mac}. This generates a digest for valueToDigest
+     * and the key the Mac was initialized
+     *
+     * @param mac
+     *            the initialized {@link Mac} to update
+     * @param valueToDigest
+     *            the value to update the {@link Mac} with (maybe null or empty)
+     * @return the updated {@link Mac}
+     * @throws IllegalStateException
+     *             if the Mac was not initialized
+     * @since 1.x
+     */
+    public static Mac updateHmac(final Mac mac, final String valueToDigest) {
+        mac.reset();
+        mac.update(StringUtils.getBytesUtf8(valueToDigest));
+        return mac;
+    }
 
-	/**
-	 * Updates the given {@link Mac}. This generates a digest for valueToDigest
-	 * and the key the Mac was initialized
-	 * 
-	 * @param mac
-	 *            the initialized {@link Mac} to update
-	 * @param valueToDigest
-	 *            the value to update the {@link Mac} with (maybe null or empty)
-	 * @return the updated {@link Mac}
-	 * @throws IllegalStateException
-	 *             if the Mac was not initialized
-	 * @since 1.x
-	 */
-	public static Mac updateHmac(final Mac mac, final String valueToDigest) {
-		mac.reset();
-		mac.update(StringUtils.getBytesUtf8(valueToDigest));
-		return mac;
-	}
+    /**
+     * Updates the given {@link Mac}. This generates a digest for valueToDigest
+     * and the key the Mac was initialized
+     *
+     * @param mac
+     *            the initialized {@link Mac} to update
+     * @param valueToDigest
+     *            the value to update the {@link Mac} with
+     *            <p>
+     *            The Inputstream must not be null and will not be closed
+     *            </p>
+     * @return the updated {@link Mac}
+     * @throws IllegalStateException
+     *             if the Mac was not initialized
+     * @since 1.x
+     */
+    public static Mac updateHmac(final Mac mac, final InputStream valueToDigest)
+            throws IOException {
+        mac.reset();
+        final byte[] buffer = new byte[STREAM_BUFFER_LENGTH];
+        int read = valueToDigest.read(buffer, 0, STREAM_BUFFER_LENGTH);
 
-	/**
-	 * Updates the given {@link Mac}. This generates a digest for valueToDigest
-	 * and the key the Mac was initialized
-	 * 
-	 * @param mac
-	 *            the initialized {@link Mac} to update
-	 * @param valueToDigest
-	 *            the value to update the {@link Mac} with
-	 *            <p>
-	 *            The Inputstream must not be null and will not be closed
-	 *            </p>
-	 * @return the updated {@link Mac}
-	 * @throws IllegalStateException
-	 *             if the Mac was not initialized
-	 * @since 1.x
-	 */
-	public static Mac updateHmac(final Mac mac, final InputStream valueToDigest)
-			throws IOException {
-		mac.reset();
-		final byte[] buffer = new byte[STREAM_BUFFER_LENGTH];
-		int read = valueToDigest.read(buffer, 0, STREAM_BUFFER_LENGTH);
+        while (read > -1) {
+            mac.update(buffer, 0, read);
+            read = valueToDigest.read(buffer, 0, STREAM_BUFFER_LENGTH);
+        }
 
-		while (read > -1) {
-			mac.update(buffer, 0, read);
-			read = valueToDigest.read(buffer, 0, STREAM_BUFFER_LENGTH);
-		}
-
-		return mac;
-	}
+        return mac;
+    }
 }

--- a/src/test/java/org/apache/commons/codec/digest/HmacUtilsTest.java
+++ b/src/test/java/org/apache/commons/codec/digest/HmacUtilsTest.java
@@ -24,9 +24,11 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
 import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.codec.binary.StringUtils;
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -35,12 +37,158 @@ import org.junit.Test;
  * @version $Id$
  */
 public class HmacUtilsTest {
+    
+    private static final String STANDARD_KEY_STRING = "key";
+    private static final byte[] STANDARD_KEY_BYTES = STANDARD_KEY_STRING.getBytes();
+    private static final String STANDARD_PHRASE_STRING = "The quick brown fox jumps over the lazy dog";
+    private static final byte[] STANDARD_PHRASE_BYTES = STANDARD_PHRASE_STRING.getBytes();
+    private static final String STANDARD_MD5_RESULT_STRING =    "80070713463e7749b90c2dc24911e275";
+    private static final String STANDARD_SHA1_RESULT_STRING =   "de7c9b85b8b78aa6bc8a7a36f70a90701c9db4d9";
+    private static final String STANDARD_SHA256_RESULT_STRING = "f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8";
+    private static final String STANDARD_SHA384_RESULT_STRING = "D7F4727E2C0B39AE0F1E40CC96F60242D5B7801841CEA6FC592C5D3E1AE50700582A96CF35E1E554995FE4E03381C237".toLowerCase();
+    private static final String STANDARD_SHA512_RESULT_STRING = "B42AF09057BAC1E2D41708E48A902E09B5FF7F12AB428A4FE86653C73DD248FB82F948A549F7B791A5B41915EE4D1EC3935357E4E2317250D0372AFA2EBEEB3A".toLowerCase();
 
+
+    private static final byte[] STANDARD_MD5_RESULT_BYTES = new byte[]{-128, 7, 7, 19, 70, 62, 119, 73, -71, 12, 45, -62, 73, 17, -30, 117};
+    private static final byte[] STANDARD_SHA1_RESULT_BYTES = new byte[]{-34, 124, -101, -123, -72, -73, -118, -90, -68, -118, 122, 54, -9, 10, -112, 112, 28, -99, -76, -39};
+    private static final byte[] STANDARD_SHA256_RESULT_BYTES   = new byte[]{-9, -68, -125, -12, 48, 83, -124, 36, -79, 50, -104, -26, -86, 111, -79, 67, -17, 77, 89, -95, 73, 70, 23, 89, -105, 71, -99, -68, 45, 26, 60, -40};
+    private static final byte[] STANDARD_SHA384_RESULT_BYTES =  new byte[]{-41, -12, 114, 126, 44, 11, 57, -82, 15, 30, 64, -52, -106, -10, 2, 66, -43, -73, -128, 24, 65, -50, -90, -4, 89, 44, 93, 62, 26, -27, 7, 0, 88, 42, -106, -49, 53, -31, -27, 84, -103, 95, -28, -32, 51, -127, -62, 55};
+    private static final byte[] STANDARD_SHA512_RESULT_BYTES =  new byte[]{-76, 42, -16, -112, 87, -70, -63, -30, -44, 23, 8, -28, -118, -112, 46, 9, -75, -1, 127, 18, -85, 66, -118, 79, -24, 102, 83, -57, 61, -46, 72, -5, -126, -7, 72, -91, 73, -9, -73, -111, -91, -76, 25, 21, -18, 77, 30, -61, -109, 83, 87, -28, -30, 49, 114, 80, -48, 55, 42, -6, 46, -66, -21, 58};
+
+    
+    @Test(expected=IllegalArgumentException.class)
+    public void testSecretKeySpecAllowsEmtyKeys() {      
+           new SecretKeySpec(new byte[]{}, "HmacMD5");         
+    }
+    
 	@Test
 	public void testConstructable() {
 		assertNotNull(new HmacUtils());
 	}
 
+	
+	@Test
+    public void testInitializedMac() throws IOException {
+        Mac md5Mac = HmacUtils.getInitializedMac(HmacAlgorithms.HMAC_MD5, STANDARD_KEY_BYTES);
+        Mac md5Mac2 = HmacUtils.getInitializedMac("HmacMD5", STANDARD_KEY_BYTES);
+       
+        Assert.assertArrayEquals(STANDARD_MD5_RESULT_BYTES,
+                HmacUtils.updateHmac(md5Mac, STANDARD_PHRASE_STRING).doFinal());
+        
+        Assert.assertArrayEquals(STANDARD_MD5_RESULT_BYTES,
+                HmacUtils.updateHmac(md5Mac2, STANDARD_PHRASE_STRING).doFinal());
+
+    }
+	
+	@Test(expected = IllegalArgumentException.class)
+    public void testInitializedMacNullKey() throws IOException {
+        HmacUtils.getInitializedMac(HmacAlgorithms.HMAC_MD5, null);
+    }
+	
+	@Test(expected = IllegalArgumentException.class)
+    public void testInitializedMacNullAlgo() throws IOException {
+        HmacUtils.getInitializedMac((String) null, STANDARD_KEY_BYTES);
+    }
+    
+	@Test
+    public void testGetHMac() throws IOException {
+        Assert.assertArrayEquals(STANDARD_MD5_RESULT_BYTES,
+                HmacUtils.getHmacMd5(STANDARD_KEY_BYTES).doFinal(STANDARD_PHRASE_BYTES));
+        
+        Assert.assertArrayEquals(STANDARD_SHA1_RESULT_BYTES,
+                HmacUtils.getHmacSha1(STANDARD_KEY_BYTES).doFinal(STANDARD_PHRASE_BYTES));
+        
+        Assert.assertArrayEquals(STANDARD_SHA256_RESULT_BYTES,
+                HmacUtils.getHmacSha256(STANDARD_KEY_BYTES).doFinal(STANDARD_PHRASE_BYTES));
+        
+        Assert.assertArrayEquals(STANDARD_SHA384_RESULT_BYTES,
+                HmacUtils.getHmacSha384(STANDARD_KEY_BYTES).doFinal(STANDARD_PHRASE_BYTES));
+        
+        Assert.assertArrayEquals(STANDARD_SHA512_RESULT_BYTES,
+                HmacUtils.getHmacSha512(STANDARD_KEY_BYTES).doFinal(STANDARD_PHRASE_BYTES));	    
+    }
+	
+    @Test
+    public void testMd5HMac() throws IOException {
+        Assert.assertArrayEquals(STANDARD_MD5_RESULT_BYTES,HmacUtils.hmacMd5(STANDARD_KEY_BYTES, STANDARD_PHRASE_BYTES));
+        Assert.assertArrayEquals(STANDARD_MD5_RESULT_BYTES,HmacUtils.hmacMd5(STANDARD_KEY_BYTES, new ByteArrayInputStream(STANDARD_PHRASE_BYTES)));
+        Assert.assertArrayEquals(STANDARD_MD5_RESULT_BYTES,HmacUtils.hmacMd5(STANDARD_KEY_STRING, STANDARD_PHRASE_STRING));
+        
+        Assert.assertEquals(STANDARD_MD5_RESULT_STRING,HmacUtils.hmacMd5Hex(STANDARD_KEY_BYTES, STANDARD_PHRASE_BYTES));
+        Assert.assertEquals(STANDARD_MD5_RESULT_STRING,HmacUtils.hmacMd5Hex(STANDARD_KEY_BYTES, new ByteArrayInputStream(STANDARD_PHRASE_BYTES)));
+        Assert.assertEquals(STANDARD_MD5_RESULT_STRING,HmacUtils.hmacMd5Hex(STANDARD_KEY_STRING, STANDARD_PHRASE_STRING));
+    }
+    
+    @Test
+    public void testSha1HMac() throws IOException {
+        Assert.assertArrayEquals(STANDARD_SHA1_RESULT_BYTES,HmacUtils.hmacSha1(STANDARD_KEY_BYTES, STANDARD_PHRASE_BYTES));
+        Assert.assertArrayEquals(STANDARD_SHA1_RESULT_BYTES,HmacUtils.hmacSha1(STANDARD_KEY_BYTES, new ByteArrayInputStream(STANDARD_PHRASE_BYTES)));
+        Assert.assertArrayEquals(STANDARD_SHA1_RESULT_BYTES,HmacUtils.hmacSha1(STANDARD_KEY_STRING, STANDARD_PHRASE_STRING));
+        
+        Assert.assertEquals(STANDARD_SHA1_RESULT_STRING,HmacUtils.hmacSha1Hex(STANDARD_KEY_BYTES, STANDARD_PHRASE_BYTES));
+        Assert.assertEquals(STANDARD_SHA1_RESULT_STRING,HmacUtils.hmacSha1Hex(STANDARD_KEY_BYTES, new ByteArrayInputStream(STANDARD_PHRASE_BYTES)));
+        Assert.assertEquals(STANDARD_SHA1_RESULT_STRING,HmacUtils.hmacSha1Hex(STANDARD_KEY_STRING, STANDARD_PHRASE_STRING));
+    }
+    
+    @Test
+    public void testSha256HMac() throws IOException {
+        Assert.assertArrayEquals(STANDARD_SHA256_RESULT_BYTES,HmacUtils.hmacSha256(STANDARD_KEY_BYTES, STANDARD_PHRASE_BYTES));
+        Assert.assertArrayEquals(STANDARD_SHA256_RESULT_BYTES,HmacUtils.hmacSha256(STANDARD_KEY_BYTES, new ByteArrayInputStream(STANDARD_PHRASE_BYTES)));
+        Assert.assertArrayEquals(STANDARD_SHA256_RESULT_BYTES,HmacUtils.hmacSha256(STANDARD_KEY_STRING, STANDARD_PHRASE_STRING));
+        
+        Assert.assertEquals(STANDARD_SHA256_RESULT_STRING,HmacUtils.hmacSha256Hex(STANDARD_KEY_BYTES, STANDARD_PHRASE_BYTES));
+        Assert.assertEquals(STANDARD_SHA256_RESULT_STRING,HmacUtils.hmacSha256Hex(STANDARD_KEY_BYTES, new ByteArrayInputStream(STANDARD_PHRASE_BYTES)));
+        Assert.assertEquals(STANDARD_SHA256_RESULT_STRING,HmacUtils.hmacSha256Hex(STANDARD_KEY_STRING, STANDARD_PHRASE_STRING));
+    }
+    
+    @Test
+    public void testSha384HMac() throws IOException {
+        Assert.assertArrayEquals(STANDARD_SHA384_RESULT_BYTES,HmacUtils.hmacSha384(STANDARD_KEY_BYTES, STANDARD_PHRASE_BYTES));
+        Assert.assertArrayEquals(STANDARD_SHA384_RESULT_BYTES,HmacUtils.hmacSha384(STANDARD_KEY_BYTES, new ByteArrayInputStream(STANDARD_PHRASE_BYTES)));
+        Assert.assertArrayEquals(STANDARD_SHA384_RESULT_BYTES,HmacUtils.hmacSha384(STANDARD_KEY_STRING, STANDARD_PHRASE_STRING));
+        
+        Assert.assertEquals(STANDARD_SHA384_RESULT_STRING,HmacUtils.hmacSha384Hex(STANDARD_KEY_BYTES, STANDARD_PHRASE_BYTES));
+        Assert.assertEquals(STANDARD_SHA384_RESULT_STRING,HmacUtils.hmacSha384Hex(STANDARD_KEY_BYTES, new ByteArrayInputStream(STANDARD_PHRASE_BYTES)));
+        Assert.assertEquals(STANDARD_SHA384_RESULT_STRING,HmacUtils.hmacSha384Hex(STANDARD_KEY_STRING, STANDARD_PHRASE_STRING));
+    }
+    
+    @Test
+    public void testSha512HMac() throws IOException {
+        Assert.assertArrayEquals(STANDARD_SHA512_RESULT_BYTES,HmacUtils.hmacSha512(STANDARD_KEY_BYTES, STANDARD_PHRASE_BYTES));
+        Assert.assertArrayEquals(STANDARD_SHA512_RESULT_BYTES,HmacUtils.hmacSha512(STANDARD_KEY_BYTES, new ByteArrayInputStream(STANDARD_PHRASE_BYTES)));
+        Assert.assertArrayEquals(STANDARD_SHA512_RESULT_BYTES,HmacUtils.hmacSha512(STANDARD_KEY_STRING, STANDARD_PHRASE_STRING));
+        
+        Assert.assertEquals(STANDARD_SHA512_RESULT_STRING,HmacUtils.hmacSha512Hex(STANDARD_KEY_BYTES, STANDARD_PHRASE_BYTES));
+        Assert.assertEquals(STANDARD_SHA512_RESULT_STRING,HmacUtils.hmacSha512Hex(STANDARD_KEY_BYTES, new ByteArrayInputStream(STANDARD_PHRASE_BYTES)));
+        Assert.assertEquals(STANDARD_SHA512_RESULT_STRING,HmacUtils.hmacSha512Hex(STANDARD_KEY_STRING, STANDARD_PHRASE_STRING));
+    }
+    
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testMd5HMacFail() throws IOException {
+        HmacUtils.hmacMd5((byte[]) null, STANDARD_PHRASE_BYTES);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testSha1HMacFail() throws IOException {
+        HmacUtils.hmacSha1((byte[]) null, STANDARD_PHRASE_BYTES);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testSha256HMacFail() throws IOException {
+        HmacUtils.hmacSha256((byte[]) null, STANDARD_PHRASE_BYTES);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testSha384HMacFail() throws IOException {
+        HmacUtils.hmacSha384((byte[]) null, STANDARD_PHRASE_BYTES);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testSha512HMacFail() throws IOException {
+        HmacUtils.hmacSha512((byte[]) null, STANDARD_PHRASE_BYTES);
+    }  
+	
 	@Test(expected = IllegalArgumentException.class)
 	public void testInternalNoSuchAlgorithmException() {
 		HmacUtils.getInitializedMac("Bogus Bogus",
@@ -51,18 +199,16 @@ public class HmacUtilsTest {
 	public void testNullKey() {
 		HmacUtils.getHmacMd5(null);
 	}
+	
+	@Test(expected = IllegalArgumentException.class)
+    public void testEmptyKey() {
+        HmacUtils.getHmacMd5(new byte[]{});
+    }
 
 	@Test
 	public void testHmacMd5Hex() throws IOException {
-
-		assertEquals("74e6f7298a9c2d168935f58c001bad88",
-				HmacUtils.hmacMd5Hex("", null));
-
-		assertEquals("74e6f7298a9c2d168935f58c001bad88",
-				HmacUtils.hmacMd5Hex("", ""));
-
 		assertEquals("80070713463e7749b90c2dc24911e275", HmacUtils.hmacMd5Hex(
-				"key", "The quick brown fox jumps over the lazy dog"));
+		        STANDARD_KEY_STRING, "The quick brown fox jumps over the lazy dog"));
 
 		assertEquals("750c783e6ab0b503eaa86e310a5db738",
 				HmacUtils.hmacMd5Hex("Jefe", "what do ya want for nothing?"));
@@ -70,24 +216,16 @@ public class HmacUtilsTest {
 		assertEquals("750c783e6ab0b503eaa86e310a5db738", HmacUtils.hmacMd5Hex(
 				"Jefe".getBytes(), new ByteArrayInputStream(
 						"what do ya want for nothing?".getBytes())));
-
 	}
 
 	@Test
 	public void testHmacSha1Hex() throws IOException {
-
-		assertEquals("fbdb1d1b18aa6c08324b7d64b71fb76370690e1d",
-				HmacUtils.hmacSha1Hex("", null));
-
-		assertEquals("fbdb1d1b18aa6c08324b7d64b71fb76370690e1d",
-				HmacUtils.hmacSha1Hex("", ""));
-
-		assertEquals("de7c9b85b8b78aa6bc8a7a36f70a90701c9db4d9",
-				HmacUtils.hmacSha1Hex("key",
-						"The quick brown fox jumps over the lazy dog"));
+		assertEquals(STANDARD_SHA1_RESULT_STRING,
+				HmacUtils.hmacSha1Hex(STANDARD_KEY_STRING,
+				        STANDARD_PHRASE_STRING));
 
 		assertEquals("f42bb0eeb018ebbd4597ae7213711ec60760843f",
-				HmacUtils.hmacSha1Hex("key", ""));
+				HmacUtils.hmacSha1Hex(STANDARD_KEY_STRING, ""));
 
 		assertEquals("effcdf6ae5eb2fa2d27416d5f184df9c259a7c79",
 				HmacUtils.hmacSha1Hex("Jefe", "what do ya want for nothing?"));
@@ -97,97 +235,34 @@ public class HmacUtilsTest {
 						"Jefe".getBytes(),
 						new ByteArrayInputStream("what do ya want for nothing?"
 								.getBytes())));
-
 	}
 
-	@Test
-	public void testHmacSha256Hex() throws IOException {
-
-		assertEquals(
-				"b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad",
-				HmacUtils.hmacSha256Hex("", null));
-
-		assertEquals(
-				"b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad",
-				HmacUtils.hmacSha256Hex("", ""));
-
-		assertEquals(
-				"f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8",
-				HmacUtils.hmacSha256Hex("key",
-						"The quick brown fox jumps over the lazy dog"));
-	}
-
-	@Test
-	public void testHmacSha384Hex() throws IOException {
-
-		assertEquals(
-				"6C1F2EE938FAD2E24BD91298474382CA218C75DB3D83E114B3D4367776D14D3551289E75E8209CD4B792302840234ADC"
-						.toLowerCase(), HmacUtils.hmacSha384Hex("", null));
-
-		assertEquals(
-				"6C1F2EE938FAD2E24BD91298474382CA218C75DB3D83E114B3D4367776D14D3551289E75E8209CD4B792302840234ADC"
-						.toLowerCase(), HmacUtils.hmacSha384Hex("", ""));
-
-		assertEquals(
-				"D7F4727E2C0B39AE0F1E40CC96F60242D5B7801841CEA6FC592C5D3E1AE50700582A96CF35E1E554995FE4E03381C237"
-						.toLowerCase(), HmacUtils.hmacSha384Hex("key",
-						"The quick brown fox jumps over the lazy dog"));
-	}
-
-	@Test
-	public void testHmacSha512Hex() throws IOException {
-
-		assertEquals(
-				"B936CEE86C9F87AA5D3C6F2E84CB5A4239A5FE50480A6EC66B70AB5B1F4AC6730C6C515421B327EC1D69402E53DFB49AD7381EB067B338FD7B0CB22247225D47"
-						.toLowerCase(), HmacUtils.hmacSha512Hex("", null));
-
-		assertEquals(
-				"B936CEE86C9F87AA5D3C6F2E84CB5A4239A5FE50480A6EC66B70AB5B1F4AC6730C6C515421B327EC1D69402E53DFB49AD7381EB067B338FD7B0CB22247225D47"
-						.toLowerCase(), HmacUtils.hmacSha512Hex("", ""));
-
-		assertEquals(
-				"B42AF09057BAC1E2D41708E48A902E09B5FF7F12AB428A4FE86653C73DD248FB82F948A549F7B791A5B41915EE4D1EC3935357E4E2317250D0372AFA2EBEEB3A"
-						.toLowerCase(), HmacUtils.hmacSha512Hex("key",
-						"The quick brown fox jumps over the lazy dog"));
-	}
 
 	@Test
 	public void testHmacSha1UpdateWithByteArray() throws IOException {
-
-		Mac mac = HmacUtils.getHmacSha1("key".getBytes());
-		HmacUtils.updateHmac(mac,
-				"The quick brown fox jumps over the lazy dog".getBytes());
-		assertEquals("de7c9b85b8b78aa6bc8a7a36f70a90701c9db4d9",
-				Hex.encodeHexString(mac.doFinal()));
+		Mac mac = HmacUtils.getHmacSha1(STANDARD_KEY_BYTES);
+		HmacUtils.updateHmac(mac, STANDARD_PHRASE_BYTES);
+		assertEquals(STANDARD_SHA1_RESULT_STRING, Hex.encodeHexString(mac.doFinal()));
 		HmacUtils.updateHmac(mac, "".getBytes());
-		assertEquals("f42bb0eeb018ebbd4597ae7213711ec60760843f",
-				Hex.encodeHexString(mac.doFinal()));
+		assertEquals("f42bb0eeb018ebbd4597ae7213711ec60760843f", Hex.encodeHexString(mac.doFinal()));
 	}
 
 	@Test
 	public void testHmacSha1UpdateWithInpustream() throws IOException {
-
-		Mac mac = HmacUtils.getHmacSha1("key".getBytes());
-		HmacUtils.updateHmac(mac, new ByteArrayInputStream(
-				"The quick brown fox jumps over the lazy dog".getBytes()));
-		assertEquals("de7c9b85b8b78aa6bc8a7a36f70a90701c9db4d9",
-				Hex.encodeHexString(mac.doFinal()));
+		Mac mac = HmacUtils.getHmacSha1(STANDARD_KEY_BYTES);
+		HmacUtils.updateHmac(mac, new ByteArrayInputStream(STANDARD_PHRASE_BYTES));
+		assertEquals(STANDARD_SHA1_RESULT_STRING, Hex.encodeHexString(mac.doFinal()));
 		HmacUtils.updateHmac(mac, new ByteArrayInputStream("".getBytes()));
-		assertEquals("f42bb0eeb018ebbd4597ae7213711ec60760843f",
-				Hex.encodeHexString(mac.doFinal()));
+		assertEquals("f42bb0eeb018ebbd4597ae7213711ec60760843f", Hex.encodeHexString(mac.doFinal()));
 	}
 
 	@Test
 	public void testHmacSha1UpdateWithString() throws IOException {
-
-		Mac mac = HmacUtils.getHmacSha1("key".getBytes());
-		HmacUtils
-				.updateHmac(mac, "The quick brown fox jumps over the lazy dog");
-		assertEquals("de7c9b85b8b78aa6bc8a7a36f70a90701c9db4d9",
-				Hex.encodeHexString(mac.doFinal()));
+		Mac mac = HmacUtils.getHmacSha1(STANDARD_KEY_BYTES);
+		HmacUtils.updateHmac(mac, STANDARD_PHRASE_STRING);
+		assertEquals(STANDARD_SHA1_RESULT_STRING, Hex.encodeHexString(mac.doFinal()));
 		HmacUtils.updateHmac(mac, "");
-		assertEquals("f42bb0eeb018ebbd4597ae7213711ec60760843f",
-				Hex.encodeHexString(mac.doFinal()));
+		assertEquals("f42bb0eeb018ebbd4597ae7213711ec60760843f", Hex.encodeHexString(mac.doFinal()));
 	}
 
 }


### PR DESCRIPTION
Added support for HMAC Message Authentication Code (MAC) digests like HmacMD5 or HMacSHA1 as defined in RFC 2104.
