### PR TITLE
Support decoding of Base64 with intermediary padding.

### DIFF
--- a/src/test/java/org/apache/commons/codec/binary/Base64Test.java
+++ b/src/test/java/org/apache/commons/codec/binary/Base64Test.java
@@ -138,23 +138,20 @@ public class Base64Test {
 	}
 
 	/**
-	 * Test our decode with pad character in the middle. (Our current
-	 * implementation: halt decode and return what we've got so far).
+	 * Test our decode with pad character in the middle.
+	 * 
+	 * The current implementation does not halt decoding, but carries on regardless.
 	 *
-	 * The point of this test is not to say
-	 * "this is the correct way to decode base64." The point is simply to keep
-	 * us aware of the current logic since 1.4 so we don't accidentally break it
-	 * without realizing.
-	 *
-	 * Note for historians. The 1.3 logic would decode to:
-	 * "Hello World\u0000Hello World" -- null in the middle --- and 1.4
-	 * unwittingly changed it to current logic.
+	 * Note for historians. 
+	 *  The 1.4 logic would stop decoding at the first pad and return what we had.
+	 *  The 1.3 logic would decode to:
+	 * "Hello World\u0000Hello World" -- null in the middle --- 
 	 */
 	@Test
 	public void testDecodeWithInnerPad() {
 		final String content = "SGVsbG8gV29ybGQ=SGVsbG8gV29ybGQ=";
 		final byte[] result = Base64.decodeBase64(content);
-		final byte[] shouldBe = StringUtils.getBytesUtf8("Hello World");
+		final byte[] shouldBe = StringUtils.getBytesUtf8("Hello WorldHello World");
 		assertTrue("decode should halt at pad (=)", Arrays.equals(result, shouldBe));
 	}
 


### PR DESCRIPTION
Some base64 encoders in the wild incorrectly pad data before the end of
data. For instance, the string "testtesttest" might be encoded as
"dGVzdA==dGVzdA==dGVzdA==" instead of "dGVzdHRlc3R0ZXN0". This is,
technically speaking, a bug.

This patch makes the decoder tolerant to this kind of nonsense.
Intermediary padding is processed and then decoding carries on as
though a new string were provided.