### PR TITLE
CODEC-224 Add methods to DigestUtils to generate hex from MessageDigests et al. 

### DIFF
--- a/src/main/java/org/apache/commons/codec/digest/DigestUtils.java
+++ b/src/main/java/org/apache/commons/codec/digest/DigestUtils.java
@@ -23,6 +23,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.security.DigestInputStream;
+import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -851,6 +853,125 @@ public class DigestUtils {
     @Deprecated
     public static String shaHex(final String data) {
         return sha1Hex(data);
+    }
+
+    /**
+     * Returns the value of a MessageDigest as a hex string.
+     *
+     * <p>
+     *     If {@code messageDigest} implements {@link Cloneable} then it will will be cloned
+     *     before the digest is extracted, allowing for intermediate values to be generated.
+     *     If the digest does not support implement {@link Cloneable} then the state will be reset.
+     *     See the overiew of {@link MessageDigest} for more information.
+     * </p>
+     *
+     * @param messageDigest  the digest to convert.
+     * @return The value of the computed digest represented as lowercase hexadecimal digits.
+     * @since 1.11
+     */
+    public static String toHexString(MessageDigest messageDigest) {
+        return toHexString(messageDigest, true);
+    }
+
+    /**
+     * Return the value of a MessageDigest as a hex string.
+     *
+     * <p>
+     *     If {@code messageDigest} implements {@link Cloneable} then it will will be cloned
+     *     before the digest is extracted, allowing for intermediate values to be generated.
+     *     If the digest does not support implement {@link Cloneable} then the state will be reset.
+     *     See the overiew of {@link MessageDigest} for more information.
+     * </p>
+     *
+     * @param messageDigest  the digest to convert.
+     * @param useLowerCase should the result use lowercase hexadecimal digits?
+     * @return The value of the computed digest represented as a hexadecimal string.
+     * @since 1.11
+     */
+
+    public static String toHexString(MessageDigest messageDigest, boolean useLowerCase) {
+        MessageDigest possiblyClonedDigest;
+        try {
+            possiblyClonedDigest = (MessageDigest) messageDigest.clone();
+        } catch (CloneNotSupportedException e) {
+            possiblyClonedDigest = messageDigest;
+        }
+
+        return Hex.encodeHexString(possiblyClonedDigest.digest(),useLowerCase);
+    }
+
+    /**
+     * Return a lowercase hexadecimal representation of the {@link MessageDigest}
+     * associated with the DigestInputStream. This method does <strong>NOT</strong> read data from the stream.
+     * <p>
+     *     If the digest implements {@link Cloneable} then it will will be cloned
+     *     before the digest is extracted, allowing for intermediate values to be generated.
+     *     If the digest does not support implement {@link Cloneable} then the state will be reset.
+     *     See the overview of {@link MessageDigest} for more information.
+     * </p>
+     *
+     * @param stream the digest output stream holding the digest to use. .
+     * @return The value of the digest as a lowercase hexadecimal string.
+     * @since 1.11
+     */
+    public static String toHexString(DigestInputStream stream) {
+        return toHexString(stream,true);
+    }
+    /**
+     * Return a hexadecimal representation of the {@link MessageDigest}  associated with the DigestInputStream .
+     *     This method does <strong>NOT</strong> read data from the stream.
+     * <p>
+     *     If the digest implements {@link Cloneable} then it will will be cloned
+     *     before the digest is extracted, allowing for intermediate values to be generated.
+     *     If the digest does not support implement {@link Cloneable} then the state will be reset.
+     *     See the overview of {@link MessageDigest} for more information.
+     * </p>
+     *
+     * @param stream the digest output stream holding the digest to use. .
+     * @param useLowerCase should the result use lowercase  digits?
+     * @return The value of the digest  as a hexadecimal string.
+     * @since 1.11
+     */
+    public static String toHexString(DigestInputStream stream, boolean useLowerCase) {
+        return toHexString(stream.getMessageDigest(),useLowerCase);
+    }
+
+    /**
+     * Return a lowercase hexadecimal representation of the {@link MessageDigest}  associated with a DigestOutputStream.
+     *
+     * <p>
+     *     If the digest implements {@link Cloneable} then it will will be cloned
+     *     before the digest is extracted, allowing for intermediate values to be generated.
+     *     If the digest does not support implement {@link Cloneable} then the state will be reset.
+     *     See the overview of {@link MessageDigest} for more information.
+     * </p>
+     *
+     * @param stream the digest output stream holding the digest to use. .
+     * @return The value of the digest  as a lowercase hexadecimal string.
+     * @since 1.11
+     */
+
+    public static String toHexString(DigestOutputStream stream) {
+        return toHexString(stream,true);
+    }
+
+    /**
+     * Return a hexadecimal representation of the {@link MessageDigest}  associated with a DigestOutputStream .
+     *
+     * <p>
+     *     If the digest implements {@link Cloneable} then it will will be cloned
+     *     before the digest is extracted, allowing for intermediate values to be generated.
+     *     If the digest does not support implement {@link Cloneable} then the state will be reset.
+     *     See the overview of {@link MessageDigest} for more information.
+     * </p>
+     *
+     * @param stream the digest output stream holding the digest to use. .
+     * @param useLowerCase should the result use lowercase  digits?
+     * @return The value of the digest  as a hexadecimal string.
+     * @since 1.11
+     */
+    public static String toHexString(DigestOutputStream stream, boolean useLowerCase) {
+        return toHexString(stream.getMessageDigest(),useLowerCase);
     }
 
     /**

--- a/src/test/java/org/apache/commons/codec/digest/DigestUtilsTest.java
+++ b/src/test/java/org/apache/commons/codec/digest/DigestUtilsTest.java
@@ -21,10 +21,13 @@ import static org.apache.commons.codec.binary.StringUtils.getBytesUtf8;
 import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.security.DigestInputStream;
+import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.util.Random;
 
@@ -44,6 +47,8 @@ import org.junit.Test;
  */
 public class DigestUtilsTest {
 
+    private static final String MD5_OF_ABC = "900150983cd24fb0d6963f7d28e17f72";
+    private static final String SHA1_OF_ABC = "a9993e364706816aba3e25717850c26c9cd0d89d";
     private final byte[] testData = new byte[1024 * 1024];
 
     private File testFile;
@@ -141,7 +146,7 @@ public class DigestUtilsTest {
 
         assertEquals("0cc175b9c0f1b6a831c399e269772661", DigestUtils.md5Hex("a"));
 
-        assertEquals("900150983cd24fb0d6963f7d28e17f72", DigestUtils.md5Hex("abc"));
+        assertEquals(MD5_OF_ABC, DigestUtils.md5Hex("abc"));
 
         assertEquals("f96b697d7cb7938d525a2f31aaf161d0", DigestUtils.md5Hex("message digest"));
 
@@ -190,9 +195,9 @@ public class DigestUtilsTest {
     @Test
     public void testSha1Hex() throws IOException {
         // Examples from FIPS 180-1
-        assertEquals("a9993e364706816aba3e25717850c26c9cd0d89d", DigestUtils.sha1Hex("abc"));
+        assertEquals(SHA1_OF_ABC, DigestUtils.sha1Hex("abc"));
 
-        assertEquals("a9993e364706816aba3e25717850c26c9cd0d89d", DigestUtils.sha1Hex(getBytesUtf8("abc")));
+        assertEquals(SHA1_OF_ABC, DigestUtils.sha1Hex(getBytesUtf8("abc")));
 
         assertEquals(
             "84983e441c3bd26ebaae4aa1f95129e5e54670f1",
@@ -322,9 +327,9 @@ public class DigestUtilsTest {
     @Test
     public void testShaHex() throws IOException {
         // Examples from FIPS 180-1
-        assertEquals("a9993e364706816aba3e25717850c26c9cd0d89d", DigestUtils.shaHex("abc"));
+        assertEquals(SHA1_OF_ABC, DigestUtils.shaHex("abc"));
 
-        assertEquals("a9993e364706816aba3e25717850c26c9cd0d89d", DigestUtils.shaHex(getBytesUtf8("abc")));
+        assertEquals(SHA1_OF_ABC, DigestUtils.shaHex(getBytesUtf8("abc")));
 
         assertEquals(
             "84983e441c3bd26ebaae4aa1f95129e5e54670f1",
@@ -369,6 +374,33 @@ public class DigestUtilsTest {
         final String actualResult = Hex.encodeHexString(messageDigest.digest());
 
         assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void testToHexString() throws IOException {
+        MessageDigest md5 = DigestUtils.getMd5Digest();
+        DigestUtils.updateDigest(md5, "abc");
+        assertEquals(MD5_OF_ABC, DigestUtils.toHexString(md5));
+        // check digest was not been reset
+        assertEquals(MD5_OF_ABC, DigestUtils.toHexString(md5));
+
+        assertEquals(MD5_OF_ABC.toUpperCase(), DigestUtils.toHexString(md5, false));
+
+        DigestOutputStream os = new DigestOutputStream(new ByteArrayOutputStream(), DigestUtils.getMd5Digest());
+        byte[] abc = {'a', 'b', 'c'};
+        os.write(abc);
+        assertEquals(MD5_OF_ABC, DigestUtils.toHexString(os));
+        assertEquals(MD5_OF_ABC.toUpperCase(), DigestUtils.toHexString(os,false));
+        os.close();
+
+        DigestInputStream is = new DigestInputStream(new ByteArrayInputStream(abc),DigestUtils.getMd5Digest());
+
+        //noinspection StatementWithEmptyBody
+        while(is.read() >0);
+        assertEquals(MD5_OF_ABC, DigestUtils.toHexString(is));
+        assertEquals(MD5_OF_ABC.toUpperCase(), DigestUtils.toHexString(is,false));
+
+
     }
 
 }


### PR DESCRIPTION
This PR adds methods to DigestUtils to make it easy to generate hexadecimal strings from: 
- MessageDigest, 
- DigestInputStream,
- DigestOutputStream.

  If the underlying digest supports ```clone()```,  a clone is created before calling ```MessageDigest::digest``` to avoid resetting the state.  If this cannot be done, the original digest is used.

[Although clone is optional for MessageDigests, it seems to be almost universally supported (e.g. both the Sun and the IBM  providers implement clone for their concrete digests) ]

Signed-off-by: Simon Spero <sesuncedu@gmail.com>