### PR TITLE
Corrected vital comment issue

### DIFF
--- a/src/main/java/org/apache/commons/codec/language/Caverphone1.java
+++ b/src/main/java/org/apache/commons/codec/language/Caverphone1.java
@@ -117,7 +117,7 @@ public class Caverphone1 extends AbstractCaverphone {
         txt = txt.replaceAll("2", "");
         txt = txt.replaceAll("3", "");
 
-        // 6. put ten 1s on the end
+        // 6. put six 1s on the end
         txt = txt + SIX_1;
 
         // 7. take the first six characters as the code


### PR DESCRIPTION
The number 'ten' was in the comment instead of 'six' as proven by relevant surrounding code and the original Caverphone specifications referenced.