### PR TITLE
[CODEC-250] correcting handling of special character between equal letters for cologne phonetic

### DIFF
--- a/src/main/java/org/apache/commons/codec/language/ColognePhonetic.java
+++ b/src/main/java/org/apache/commons/codec/language/ColognePhonetic.java
@@ -396,7 +396,9 @@ public class ColognePhonetic implements StringEncoder {
             }
 
             lastChar = chr;
-            lastCode = code;
+            if (code != '-') {
+                lastCode = code;
+            }
         }
         return output.toString();
     }

--- a/src/test/java/org/apache/commons/codec/language/ColognePhoneticTest.java
+++ b/src/test/java/org/apache/commons/codec/language/ColognePhoneticTest.java
@@ -162,4 +162,10 @@ public class ColognePhoneticTest extends StringEncoderAbstractTest<ColognePhonet
         final String data[] = {"Meier", "Maier", "Mair", "Meyer", "Meyr", "Mejer", "Major"};
         this.checkEncodingVariations("67", data);
     }
+    
+    @Test
+    public void testSpecialCharsBetweenSameLetters() throws EncoderException {
+        final String data[] = {"Test test", "Testtest", "Test-test", "TesT#Test", "TesT?test"};
+        this.checkEncodingVariations("28282", data);
+    }
 }


### PR DESCRIPTION
Fix for [CODEC-250](https://issues.apache.org/jira/browse/CODEC-250) for handling of special characters between equal letters for cologne phonetic.
"Test-test" and "testtest" should result in the same value according to cologne phonetic.