### PR TITLE
Base64 should be open for different alphabets

### DIFF
--- a/src/main/java/org/apache/commons/codec/binary/Base64.java
+++ b/src/main/java/org/apache/commons/codec/binary/Base64.java
@@ -271,6 +271,14 @@ public class Base64 extends BaseNCodec {
      * @since 1.4
      */
     public Base64(final int lineLength, final byte[] lineSeparator, final boolean urlSafe) {
+        this(lineLength, lineSeparator, urlSafe ? URL_SAFE_ENCODE_TABLE : STANDARD_ENCODE_TABLE);
+    }
+
+    public Base64(byte[] encodeTable) {
+        this(0, CHUNK_SEPARATOR, encodeTable);
+    }
+
+    public Base64(final int lineLength, final byte[] lineSeparator, byte[] encodingTable) {
         super(BYTES_PER_UNENCODED_BLOCK, BYTES_PER_ENCODED_BLOCK,
                 lineLength,
                 lineSeparator == null ? 0 : lineSeparator.length);
@@ -294,7 +302,7 @@ public class Base64 extends BaseNCodec {
             this.lineSeparator = null;
         }
         this.decodeSize = this.encodeSize - 1;
-        this.encodeTable = urlSafe ? URL_SAFE_ENCODE_TABLE : STANDARD_ENCODE_TABLE;
+        this.encodeTable = encodingTable;
     }
 
     /**

--- a/src/main/java/org/apache/commons/codec/binary/Base64.java
+++ b/src/main/java/org/apache/commons/codec/binary/Base64.java
@@ -310,6 +310,9 @@ public class Base64 extends BaseNCodec {
         if (encodeTable == STANDARD_ENCODE_TABLE || encodeTable == URL_SAFE_ENCODE_TABLE) {
             decodeTable = DEFAULT_DECODE_TABLE;
         } else {
+            if (encodeTable.length != 64) {
+                throw new IllegalArgumentException("encodeTable must be exactly 64 bytes long");
+            }
             decodeTable = calculateDecodeTable(encodeTable);
         }
 

--- a/src/main/java/org/apache/commons/codec/binary/Base64.java
+++ b/src/main/java/org/apache/commons/codec/binary/Base64.java
@@ -274,10 +274,28 @@ public class Base64 extends BaseNCodec {
         this(lineLength, lineSeparator, urlSafe ? URL_SAFE_ENCODE_TABLE : STANDARD_ENCODE_TABLE);
     }
 
-    public Base64(byte[] encodeTable) {
-        this(0, CHUNK_SEPARATOR, encodeTable);
+    /**
+     * Creates a Base64 codec used for decoding and encoding with non-standard encodingTable-table
+     *
+     * @param encodingTable
+     *          The manual encodeTable - a byte array of 64 chars
+     */
+    public Base64(byte[] encodingTable) {
+        this(0, CHUNK_SEPARATOR, encodingTable);
     }
 
+    /**
+     * Creates a Base64 codec used for decoding and encoding with non-standard encode-table and given lineLength and lineSeparator
+     *
+     * @param lineLength
+     *            Each line of encoded data will be at most of the given length (rounded down to nearest multiple of
+     *            4). If lineLength &lt;= 0, then the output will not be divided into lines (chunks). Ignored when
+     *            decoding.
+     * @param lineSeparator
+     *            Each line of encoded data will end with this sequence of bytes.
+     * @param encodingTable
+     *          The manual encodeTable - a byte array of 64 chars
+     */
     public Base64(final int lineLength, final byte[] lineSeparator, byte[] encodingTable) {
         super(BYTES_PER_UNENCODED_BLOCK, BYTES_PER_ENCODED_BLOCK,
                 lineLength,

--- a/src/main/java/org/apache/commons/codec/binary/Base64.java
+++ b/src/main/java/org/apache/commons/codec/binary/Base64.java
@@ -79,7 +79,7 @@ public class Base64 extends BaseNCodec {
      * Thanks to "commons" project in ws.apache.org for this code.
      * http://svn.apache.org/repos/asf/webservices/commons/trunk/modules/util/
      */
-    public static final byte[] STANDARD_ENCODE_TABLE = {
+    private static final byte[] STANDARD_ENCODE_TABLE = {
             'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
             'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
             'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
@@ -92,7 +92,7 @@ public class Base64 extends BaseNCodec {
      * changed to - and _ to make the encoded Base64 results more URL-SAFE.
      * This table is only used when the Base64's mode is set to URL-SAFE.
      */
-    public static final byte[] URL_SAFE_ENCODE_TABLE = {
+    private static final byte[] URL_SAFE_ENCODE_TABLE = {
             'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
             'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
             'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',

--- a/src/main/java/org/apache/commons/codec/binary/Base64.java
+++ b/src/main/java/org/apache/commons/codec/binary/Base64.java
@@ -79,7 +79,7 @@ public class Base64 extends BaseNCodec {
      * Thanks to "commons" project in ws.apache.org for this code.
      * http://svn.apache.org/repos/asf/webservices/commons/trunk/modules/util/
      */
-    private static final byte[] STANDARD_ENCODE_TABLE = {
+    public static final byte[] STANDARD_ENCODE_TABLE = {
             'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
             'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
             'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
@@ -92,7 +92,7 @@ public class Base64 extends BaseNCodec {
      * changed to - and _ to make the encoded Base64 results more URL-SAFE.
      * This table is only used when the Base64's mode is set to URL-SAFE.
      */
-    private static final byte[] URL_SAFE_ENCODE_TABLE = {
+    public static final byte[] URL_SAFE_ENCODE_TABLE = {
             'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
             'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
             'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
@@ -275,13 +275,13 @@ public class Base64 extends BaseNCodec {
     }
 
     /**
-     * Creates a Base64 codec used for decoding and encoding with non-standard encodingTable-table
+     * Creates a Base64 codec used for decoding and encoding with non-standard encodeTable-table
      *
-     * @param encodingTable
+     * @param encodeTable
      *          The manual encodeTable - a byte array of 64 chars
      */
-    public Base64(byte[] encodingTable) {
-        this(0, CHUNK_SEPARATOR, encodingTable);
+    public Base64(byte[] encodeTable) {
+        this(0, CHUNK_SEPARATOR, encodeTable);
     }
 
     /**
@@ -293,10 +293,10 @@ public class Base64 extends BaseNCodec {
      *            decoding.
      * @param lineSeparator
      *            Each line of encoded data will end with this sequence of bytes.
-     * @param encodingTable
+     * @param encodeTable
      *          The manual encodeTable - a byte array of 64 chars
      */
-    public Base64(final int lineLength, final byte[] lineSeparator, byte[] encodingTable) {
+    public Base64(final int lineLength, final byte[] lineSeparator, byte[] encodeTable) {
         super(BYTES_PER_UNENCODED_BLOCK, BYTES_PER_ENCODED_BLOCK,
                 lineLength,
                 lineSeparator == null ? 0 : lineSeparator.length);
@@ -320,7 +320,7 @@ public class Base64 extends BaseNCodec {
             this.lineSeparator = null;
         }
         this.decodeSize = this.encodeSize - 1;
-        this.encodeTable = encodingTable;
+        this.encodeTable = encodeTable;
     }
 
     /**
@@ -339,7 +339,7 @@ public class Base64 extends BaseNCodec {
      * the data to encode, and once with inAvail set to "-1" to alert encoder that EOF has been reached, to flush last
      * remaining bytes (if not multiple of 3).
      * </p>
-     * <p><b>Note: no padding is added when encoding using the URL-safe alphabet.</b></p>
+     * <p><b>Note: no padding is added when encoding not using the default alphabet.</b></p>
      * <p>
      * Thanks to "commons" project in ws.apache.org for the bitwise operations, and general approach.
      * http://svn.apache.org/repos/asf/webservices/commons/trunk/modules/util/

--- a/src/test/java/org/apache/commons/codec/binary/Base64Test.java
+++ b/src/test/java/org/apache/commons/codec/binary/Base64Test.java
@@ -116,6 +116,14 @@ public class Base64Test {
         assertEquals("decode hello world", "Hello World", decodeString);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testCustomEncodingAlphabet_illegal() {
+        byte[] encodeTable = {
+                '.', '-', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M'
+        };
+        Base64 b64customEncoding = new Base64(encodeTable);
+    }
+
     @Test
     public void testCustomEncodingAlphabet() {
         // created a duplicate of STANDARD_ENCODE_TABLE and replaced two chars with

--- a/src/test/java/org/apache/commons/codec/binary/Base64Test.java
+++ b/src/test/java/org/apache/commons/codec/binary/Base64Test.java
@@ -128,7 +128,7 @@ public class Base64Test {
         Base64 b64 = new Base64();
         Base64 b64customEncoding = new Base64(encodeTable);
 
-        final String content = "Hello World - this ";
+        final String content = "! Hello World - this §$%";
 
         byte[] encodedBytes = b64.encode(StringUtils.getBytesUtf8(content));
         String encodedContent = StringUtils.newStringUtf8(encodedBytes);
@@ -144,6 +144,13 @@ public class Base64Test {
                         .replaceAll("A", ".").replaceAll("B", "-") // replace alphabet adjustments
                         .replaceAll("=", "") // remove padding (not default alphabet)
                 , encodedContentCustom);
+
+
+        // try decode encoded content
+        final byte[] decode = b64customEncoding.decode(encodedBytesCustom);
+        final String decodeString = StringUtils.newStringUtf8(decode);
+
+        Assert.assertEquals(content, decodeString);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/codec/binary/Base64Test.java
+++ b/src/test/java/org/apache/commons/codec/binary/Base64Test.java
@@ -118,11 +118,16 @@ public class Base64Test {
 
     @Test
     public void testCustomEncodingAlphabet() {
-        // create a duplicate of STANDARD_ENCODE_TABLE and replace two chars with
+        // created a duplicate of STANDARD_ENCODE_TABLE and replaced two chars with
         // custom values not already present in table
-        byte[] encodeTable = Arrays.copyOf(Base64.STANDARD_ENCODE_TABLE, 64);
-        encodeTable[0] = '.';
-        encodeTable[1] = '-';
+        // A => .   B => -
+        byte[] encodeTable = {
+                '.', '-', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+                'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+                'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+                'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+                '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'
+        };
 
         // two instances: one with default table and one with adjusted encoding table
         Base64 b64 = new Base64();
@@ -137,7 +142,7 @@ public class Base64Test {
         String encodedContentCustom = StringUtils.newStringUtf8(encodedBytesCustom);
 
         Assert.assertTrue("testing precondition not met - ecodedContent should contain parts of modified table",
-                encodedContent.contains("A") || encodedContent.contains("B"));
+                encodedContent.contains("A") && encodedContent.contains("B"));
 
         Assert.assertEquals("custom encoding mismatch to expected - " + encodedContentCustom,
                 encodedContent

--- a/src/test/java/org/apache/commons/codec/binary/Base64Test.java
+++ b/src/test/java/org/apache/commons/codec/binary/Base64Test.java
@@ -32,6 +32,7 @@ import org.apache.commons.codec.Charsets;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.EncoderException;
 import org.apache.commons.lang3.ArrayUtils;
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -113,6 +114,36 @@ public class Base64Test {
         final byte[] decode = b64.decode("SGVsbG{\u00e9\u00e9\u00e9\u00e9\u00e9\u00e9}8gV29ybGQ=");
         final String decodeString = StringUtils.newStringUtf8(decode);
         assertEquals("decode hello world", "Hello World", decodeString);
+    }
+
+    @Test
+    public void testCustomEncodingAlphabet() {
+        // create a duplicate of STANDARD_ENCODE_TABLE and replace two chars with
+        // custom values not already present in table
+        byte[] encodeTable = Arrays.copyOf(Base64.STANDARD_ENCODE_TABLE, 64);
+        encodeTable[0] = '.';
+        encodeTable[1] = '-';
+
+        // two instances: one with default table and one with adjusted encoding table
+        Base64 b64 = new Base64();
+        Base64 b64customEncoding = new Base64(encodeTable);
+
+        final String content = "Hello World - this ";
+
+        byte[] encodedBytes = b64.encode(StringUtils.getBytesUtf8(content));
+        String encodedContent = StringUtils.newStringUtf8(encodedBytes);
+
+        byte[] encodedBytesCustom = b64customEncoding.encode(StringUtils.getBytesUtf8(content));
+        String encodedContentCustom = StringUtils.newStringUtf8(encodedBytesCustom);
+
+        Assert.assertTrue("testing precondition not met - ecodedContent should contain parts of modified table",
+                encodedContent.contains("A") || encodedContent.contains("B"));
+
+        Assert.assertEquals("custom encoding mismatch to expected - " + encodedContentCustom,
+                encodedContent
+                        .replaceAll("A", ".").replaceAll("B", "-") // replace alphabet adjustments
+                        .replaceAll("=", "") // remove padding (not default alphabet)
+                , encodedContentCustom);
     }
 
     @Test


### PR DESCRIPTION
Currently I´m trying to write a Linux shadow-file - the passwords are stored as Base64-ecoded (hashes). But the alphabet of this Base64 is different:

see [www.linuxquestions.org/questions/linux-security-4/how-can-i-convert-a-sha-512-etc-shadow-hash-to-base64-4175477045/](https://www.linuxquestions.org/questions/linux-security-4/how-can-i-convert-a-sha-512-etc-shadow-hash-to-base64-4175477045/)
` A base 64 encoding is used to store password hashes computed with
crypt in the /etc/passwd. Its alphabet starts with '.' for zero,
 then '/' for one, followed by 0-9, A-Z and a-z.
 Padding is not used.`

So I opened up your Base64 class constructor to accept an alphabet.