### PR TITLE
[CODEC-270] Base32/64: Fix masked check of the final bits to discard.

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -43,6 +43,7 @@ The <action> type attribute can be add,update,fix,remove.
   <body>
 
     <release version="1.14" date="TBD" description="Feature and fix release.">
+      <action issue="CODEC-270" dev="aherbert" type="fix">Base32/64: Fixed decoding check that all the final trailing bits to discard are zero.</action>
       <action issue="CODEC-264" dev="aherbert" due-to="Claude Warren" type="add">Add MurmurHash3.hash128x64 methods to fix sign extension error during seeding in hash128 methods.</action>
       <action issue="CODEC-267" dev="aherbert" due-to="Claude Warren" type="add">Add MurmurHash3.hash32x86 methods and IncrementalHash32x86 to fix sign extension error in hash32 methods.</action>
       <action issue="CODEC-269" dev="aherbert" type="fix">Allow repeat calls to MurmurHash3.IncrementalHash32.end() to generate the same value.</action>

--- a/src/main/java/org/apache/commons/codec/binary/Base64.java
+++ b/src/main/java/org/apache/commons/codec/binary/Base64.java
@@ -128,6 +128,10 @@ public class Base64 extends BaseNCodec {
      */
     /** Mask used to extract 6 bits, used when encoding */
     private static final int MASK_6BITS = 0x3f;
+    /** Mask used to extract 4 bits, used when decoding final trailing character. */
+    private static final int MASK_4BITS = 0xf;
+    /** Mask used to extract 2 bits, used when decoding final trailing character. */
+    private static final int MASK_2BITS = 0x3;
 
     // The static final fields above are used for the original static byte[] methods on Base64.
     // The private member fields below are used with the new streaming approach, which requires
@@ -469,12 +473,12 @@ public class Base64 extends BaseNCodec {
                     // TODO not currently tested; perhaps it is impossible?
                     break;
                 case 2 : // 12 bits = 8 + 4
-                    validateCharacter(4, context);
+                    validateCharacter(MASK_4BITS, context);
                     context.ibitWorkArea = context.ibitWorkArea >> 4; // dump the extra 4 bits
                     buffer[context.pos++] = (byte) ((context.ibitWorkArea) & MASK_8BITS);
                     break;
                 case 3 : // 18 bits = 8 + 8 + 2
-                    validateCharacter(2, context);
+                    validateCharacter(MASK_2BITS, context);
                     context.ibitWorkArea = context.ibitWorkArea >> 2; // dump 2 bits
                     buffer[context.pos++] = (byte) ((context.ibitWorkArea >> 8) & MASK_8BITS);
                     buffer[context.pos++] = (byte) ((context.ibitWorkArea) & MASK_8BITS);
@@ -784,20 +788,22 @@ public class Base64 extends BaseNCodec {
     }
 
     /**
-     * <p>
-     * Validates whether the character is possible in the context of the set of possible base 64 values.
-     * </p>
+     * Validates whether decoding the final trailing character is possible in the context
+     * of the set of possible base 64 values.
      *
-     * @param numBitsToDrop number of least significant bits to check
+     * <p>The character is valid if the lower bits within the provided mask are zero. This
+     * is used to test the final trailing base-64 digit is zero in the bits that will be discarded.
+     *
+     * @param emptyBitsMask The mask of the lower bits that should be empty
      * @param context the context to be used
      *
      * @throws IllegalArgumentException if the bits being checked contain any non-zero value
      */
-    private long validateCharacter(final int numBitsToDrop, final Context context) {
-        if ((context.ibitWorkArea & numBitsToDrop) != 0) {
-        throw new IllegalArgumentException(
-            "Last encoded character (before the paddings if any) is a valid base 64 alphabet but not a possible value");
+    private static void validateCharacter(final int emptyBitsMask, final Context context) {
+        if ((context.ibitWorkArea & emptyBitsMask) != 0) {
+            throw new IllegalArgumentException(
+                "Last encoded character (before the paddings if any) is a valid base 64 alphabet but not a possible value. " +
+                "Expected the discarded bits to be zero.");
         }
-        return context.ibitWorkArea >> numBitsToDrop;
     }
 }

--- a/src/test/java/org/apache/commons/codec/binary/Base32Test.java
+++ b/src/test/java/org/apache/commons/codec/binary/Base32Test.java
@@ -71,6 +71,16 @@ public class Base32Test {
         "CPNMUOJ1E2======"
     };
 
+    /**
+     * Copy of the standard base-32 encoding table. Used to test decoding the final
+     * character of encoded bytes.
+     */
+    private static final byte[] ENCODE_TABLE = {
+            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+            'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+            '2', '3', '4', '5', '6', '7',
+    };
+
     private static final Object[][] BASE32_BINARY_TEST_CASES;
 
     //            { null, "O0o0O0o0" }
@@ -295,6 +305,75 @@ public class Base32Test {
                 fail();
             } catch (final IllegalArgumentException ex) {
                 // expected
+            }
+        }
+    }
+
+    @Test
+    public void testBase32DecodingOfTrailing10Bits() {
+        assertBase32DecodingOfTrailingBits(10);
+    }
+
+    @Test
+    public void testBase32DecodingOfTrailing15Bits() {
+        assertBase32DecodingOfTrailingBits(15);
+    }
+
+    @Test
+    public void testBase32DecodingOfTrailing20Bits() {
+        assertBase32DecodingOfTrailingBits(20);
+    }
+
+    @Test
+    public void testBase32DecodingOfTrailing25Bits() {
+        assertBase32DecodingOfTrailingBits(25);
+    }
+
+    @Test
+    public void testBase32DecodingOfTrailing30Bits() {
+        assertBase32DecodingOfTrailingBits(30);
+    }
+
+    @Test
+    public void testBase32DecodingOfTrailing35Bits() {
+        assertBase32DecodingOfTrailingBits(35);
+    }
+
+    /**
+     * Test base 32 decoding of the final trailing bits. Trailing encoded bytes
+     * cannot fit exactly into 5-bit characters so the last character has a limited
+     * alphabet where the final bits are zero. This asserts that illegal final
+     * characters throw an exception when decoding.
+     *
+     * @param nbits the number of trailing bits (must be a factor of 5 and {@code <40})
+     */
+    private static void assertBase32DecodingOfTrailingBits(int nbits) {
+        final Base32 codec = new Base32();
+        // Create the encoded bytes. The first characters must be valid so fill with 'zero'.
+        final byte[] encoded = new byte[nbits / 5];
+        Arrays.fill(encoded, ENCODE_TABLE[0]);
+        // Compute how many bits would be discarded from 8-bit bytes
+        final int discard = nbits % 8;
+        final int emptyBitsMask = (1 << discard) - 1;
+        // Enumerate all 32 possible final characters in the last position
+        final int last = encoded.length - 1;
+        for (int i = 0; i < 32; i++) {
+            encoded[last] = ENCODE_TABLE[i];
+            // If the lower bits are set we expect an exception. This is not a valid
+            // final character.
+            if ((i & emptyBitsMask) != 0) {
+                try {
+                    codec.decode(encoded);
+                    fail("Final base-32 digit should not be allowed");
+                } catch (final IllegalArgumentException ex) {
+                    // expected
+                }
+            } else {
+                // Otherwise this should decode
+                final byte[] decoded = codec.decode(encoded);
+                // Compute the bits that were encoded. This should match the final decoded byte.
+                final int bitsEncoded = i >> discard;
+                assertEquals("Invalid decoding of last character", bitsEncoded, decoded[decoded.length - 1]);
             }
         }
     }

--- a/src/test/java/org/apache/commons/codec/binary/Base32Test.java
+++ b/src/test/java/org/apache/commons/codec/binary/Base32Test.java
@@ -51,7 +51,8 @@ public class Base32Test {
         "MZXE====",
         "MZXWB===",
         "MZXW6YB=",
-        "MZXW6YTBOC======"
+        "MZXW6YTBOC======",
+        "AB======"
         };
 
     private static final String[] BASE32_IMPOSSIBLE_CASES_CHUNKED = {

--- a/src/test/java/org/apache/commons/codec/binary/Base64Test.java
+++ b/src/test/java/org/apache/commons/codec/binary/Base64Test.java
@@ -52,6 +52,18 @@ public class Base64Test {
         "AB",
     };
 
+    /**
+     * Copy of the standard base-64 encoding table. Used to test decoding the final
+     * character of encoded bytes.
+     */
+    private static final byte[] STANDARD_ENCODE_TABLE = {
+            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+            'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+            'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+            'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'
+    };
+
     private final Random random = new Random();
 
     /**
@@ -1314,6 +1326,55 @@ public class Base64Test {
                 fail();
             } catch (final IllegalArgumentException ex) {
                 // expected
+            }
+        }
+    }
+
+    @Test
+    public void testBase64DecodingOfTrailing12Bits() {
+        assertBase64DecodingOfTrailingBits(12);
+    }
+
+    @Test
+    public void testBase64DecodingOfTrailing18Bits() {
+        assertBase64DecodingOfTrailingBits(18);
+    }
+
+    /**
+     * Test base 64 decoding of the final trailing bits. Trailing encoded bytes
+     * cannot fit exactly into 6-bit characters so the last character has a limited
+     * alphabet where the final bits are zero. This asserts that illegal final
+     * characters throw an exception when decoding.
+     *
+     * @param nbits the number of trailing bits (must be a factor of 6 and {@code <24})
+     */
+    private static void assertBase64DecodingOfTrailingBits(int nbits) {
+        final Base64 codec = new Base64();
+        // Create the encoded bytes. The first characters must be valid so fill with 'zero'.
+        final byte[] encoded = new byte[nbits / 6];
+        Arrays.fill(encoded, STANDARD_ENCODE_TABLE[0]);
+        // Compute how many bits would be discarded from 8-bit bytes
+        final int discard = nbits % 8;
+        final int emptyBitsMask = (1 << discard) - 1;
+        // Enumerate all 64 possible final characters in the last position
+        final int last = encoded.length - 1;
+        for (int i = 0; i < 64; i++) {
+            encoded[last] = STANDARD_ENCODE_TABLE[i];
+            // If the lower bits are set we expect an exception. This is not a valid
+            // final character.
+            if ((i & emptyBitsMask) != 0) {
+                try {
+                    codec.decode(encoded);
+                    fail("Final base-64 digit should not be allowed");
+                } catch (final IllegalArgumentException ex) {
+                    // expected
+                }
+            } else {
+                // Otherwise this should decode
+                final byte[] decoded = codec.decode(encoded);
+                // Compute the bits that were encoded. This should match the final decoded byte.
+                final int bitsEncoded = i >> discard;
+                assertEquals("Invalid decoding of last character", bitsEncoded, decoded[decoded.length - 1]);
             }
         }
     }

--- a/src/test/java/org/apache/commons/codec/binary/Base64Test.java
+++ b/src/test/java/org/apache/commons/codec/binary/Base64Test.java
@@ -49,6 +49,7 @@ public class Base64Test {
         "ZmC=",
         "Zm9vYE==",
         "Zm9vYmC=",
+        "AB",
     };
 
     private final Random random = new Random();

--- a/src/test/java/org/apache/commons/codec/net/BCodecTest.java
+++ b/src/test/java/org/apache/commons/codec/net/BCodecTest.java
@@ -34,10 +34,12 @@ import org.junit.Test;
  */
 public class BCodecTest {
     private static final String[] BASE64_IMPOSSIBLE_CASES = {
-            "ZE==",
-            "ZmC=",
-            "Zm9vYE==",
-            "Zm9vYmC=",
+            // Require the RFC 1522 "encoded-word" header
+            "=?ASCII?B?ZE==?=",
+            "=?ASCII?B?ZmC=?=",
+            "=?ASCII?B?Zm9vYE==?=",
+            "=?ASCII?B?Zm9vYmC=?=",
+            "=?ASCII?B?AB==?="
     };
 
     static final int SWISS_GERMAN_STUFF_UNICODE[] =


### PR DESCRIPTION
Fixed the Base32/64 mask check to ensure it checks all the bits to be discarded are zero.

Added tests that enumerate all possible trailing characters. Only those with zero for the discarded bits should be decoded.

Also fixed the BCodecTest data to use the RFC 1522 "encoded-word" header.