### PR TITLE
Add RandomAccessFile digest methods

### DIFF
--- a/src/test/java/org/apache/commons/codec/digest/DigestUtilsTest.java
+++ b/src/test/java/org/apache/commons/codec/digest/DigestUtilsTest.java
@@ -24,6 +24,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.util.Random;
@@ -47,6 +48,10 @@ public class DigestUtilsTest {
 
     private File testFile;
 
+    private File testRandomAccessFile;
+
+    private RandomAccessFile testRandomAccessFileWrapper;
+
     private void assumeJava8() {
         Assume.assumeTrue(SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_1_8));
     }
@@ -63,6 +68,10 @@ public class DigestUtilsTest {
         return testFile;
     }
 
+    RandomAccessFile getTestRandomAccessFile() {
+        return testRandomAccessFileWrapper;
+    }
+
     @Before
     public void setUp() throws Exception {
         new Random().nextBytes(testData);
@@ -70,12 +79,22 @@ public class DigestUtilsTest {
         try (final FileOutputStream fos = new FileOutputStream(testFile)) {
             fos.write(testData);
         }
+
+        testRandomAccessFile = File.createTempFile(DigestUtilsTest.class.getName(), ".dat");
+        try (final FileOutputStream fos = new FileOutputStream(testRandomAccessFile)) {
+            fos.write(testData);
+        }
+        testRandomAccessFileWrapper = new RandomAccessFile(testRandomAccessFile, "rw");
     }
 
     @After
     public void tearDown() {
         if (!testFile.delete()) {
             testFile.deleteOnExit();
+        }
+
+        if (!testRandomAccessFile.delete()) {
+            testRandomAccessFile.deleteOnExit();
         }
     }
 

--- a/src/test/java/org/apache/commons/codec/digest/MessageDigestAlgorithmsTest.java
+++ b/src/test/java/org/apache/commons/codec/digest/MessageDigestAlgorithmsTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.codec.digest;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.nio.ByteBuffer;
@@ -106,6 +107,10 @@ public class MessageDigestAlgorithmsTest {
         return digestUtilsTest.getTestFile();
     }
 
+    private RandomAccessFile getTestRandomAccessFile() {
+        return digestUtilsTest.getTestRandomAccessFile();
+    }
+
     @Before
     public void setUp() throws Exception {
         digestUtilsTest = new DigestUtilsTest();
@@ -149,6 +154,25 @@ public class MessageDigestAlgorithmsTest {
         Assert.assertArrayEquals(digestTestData(),
                 DigestUtils.digest(DigestUtils.getDigest(messageDigestAlgorithm), getTestFile()));
         Assert.assertArrayEquals(digestTestData(), DigestUtils.digest(DigestUtils.getDigest(messageDigestAlgorithm),getTestFile()));
+    }
+
+    @Test
+    public void testNonBlockingDigestRandomAccessFile() throws IOException {
+        Assume.assumeTrue(DigestUtils.isAvailable(messageDigestAlgorithm));
+
+        final byte[] expected = digestTestData();
+
+        Assert.assertArrayEquals(expected,
+                DigestUtils.digest(
+                        DigestUtils.getDigest(messageDigestAlgorithm), getTestRandomAccessFile()
+                )
+        );
+
+        Assert.assertArrayEquals(expected,
+                DigestUtils.digest(
+                        DigestUtils.getDigest(messageDigestAlgorithm), getTestRandomAccessFile()
+                )
+        );
     }
 
     @Test


### PR DESCRIPTION
Added two new methods:
    
* `digest(final MessageDigest messageDigest, final RandomAccessFile data)`
* `updateDigest(final MessageDigest digest, final RandomAccessFile data)`
    
For computing digest of `RandomAccessFile`s.
    
Performance-wise there's almost no improvements offered by these new NIO based methods, but being non-blocking they could potentially use fewer resources and provide better throughput in highly multi-threaded scenarios.