### PR TITLE
[codec-259] Hex: consume all ByteBuffer.remaining() bytes

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -43,6 +43,7 @@ The <action> type attribute can be add,update,fix,remove.
   <body>
 
     <release version="1.14" date="TBD" description="Feature and fix release.">
+      <action issue="CODEC-259" dev="aherbert" type="add">Hex: Only use an available ByteBuffer backing array if the length equals the remaining byte count.</action>
       <action issue="CODEC-268" dev="aherbert" type="update">MurmurHash3: Deprecate hash64 methods and hash methods accepting a String that use the default encoding.</action>
       <action issue="CODEC-265" dev="aherbert" type="fix">BaseNCodec to expand buffer using overflow conscious code.</action>
       <action issue="CODEC-270" dev="aherbert" type="fix">Base32/64: Fixed decoding check that all the final trailing bits to discard are zero.</action>

--- a/src/main/java/org/apache/commons/codec/binary/Hex.java
+++ b/src/main/java/org/apache/commons/codec/binary/Hex.java
@@ -249,10 +249,17 @@ public class Hex implements BinaryEncoder, BinaryDecoder {
     }
 
     private static byte[] toByteArray(final ByteBuffer byteBuffer) {
+        final int remaining = byteBuffer.remaining();
+        // Use the underlying buffer if possible
         if (byteBuffer.hasArray()) {
-            return byteBuffer.array();
+            final byte[] byteArray = byteBuffer.array();
+            if (remaining == byteArray.length) {
+                //byteBuffer.position(remaining);
+                return byteArray;
+            }
         }
-        final byte[] byteArray = new byte[byteBuffer.remaining()];
+        // Copy the bytes
+        final byte[] byteArray = new byte[remaining];
         byteBuffer.get(byteArray);
         return byteArray;
     }

--- a/src/main/java/org/apache/commons/codec/binary/Hex.java
+++ b/src/main/java/org/apache/commons/codec/binary/Hex.java
@@ -125,6 +125,9 @@ public class Hex implements BinaryEncoder, BinaryDecoder {
      * returned array will be double the length of the passed array, as it takes two characters to represent any given
      * byte.
      *
+     * <p>All bytes identified by {@link ByteBuffer#remaining()} will be used; after this method
+     * the value {@link ByteBuffer#remaining() remaining()} will be zero.</p>
+     *
      * @param data a byte buffer to convert to Hex characters
      * @return A char[] containing lower-case hexadecimal characters
      * @since 1.11
@@ -151,6 +154,9 @@ public class Hex implements BinaryEncoder, BinaryDecoder {
      * Converts a byte buffer into an array of characters representing the hexadecimal values of each byte in order. The
      * returned array will be double the length of the passed array, as it takes two characters to represent any given
      * byte.
+     *
+     * <p>All bytes identified by {@link ByteBuffer#remaining()} will be used; after this method
+     * the value {@link ByteBuffer#remaining() remaining()} will be zero.</p>
      *
      * @param data        a byte buffer to convert to Hex characters
      * @param toLowerCase <code>true</code> converts to lowercase, <code>false</code> to uppercase
@@ -187,6 +193,9 @@ public class Hex implements BinaryEncoder, BinaryDecoder {
      * Converts a byte buffer into an array of characters representing the hexadecimal values of each byte in order. The
      * returned array will be double the length of the passed array, as it takes two characters to represent any given
      * byte.
+     *
+     * <p>All bytes identified by {@link ByteBuffer#remaining()} will be used; after this method
+     * the value {@link ByteBuffer#remaining() remaining()} will be zero.</p>
      *
      * @param byteBuffer a byte buffer to convert to Hex characters
      * @param toDigits   the output alphabet (must be at least 16 characters)
@@ -227,6 +236,9 @@ public class Hex implements BinaryEncoder, BinaryDecoder {
      * Converts a byte buffer into a String representing the hexadecimal values of each byte in order. The returned
      * String will be double the length of the passed array, as it takes two characters to represent any given byte.
      *
+     * <p>All bytes identified by {@link ByteBuffer#remaining()} will be used; after this method
+     * the value {@link ByteBuffer#remaining() remaining()} will be zero.</p>
+     *
      * @param data a byte buffer to convert to Hex characters
      * @return A String containing lower-case hexadecimal characters
      * @since 1.11
@@ -239,6 +251,9 @@ public class Hex implements BinaryEncoder, BinaryDecoder {
      * Converts a byte buffer into a String representing the hexadecimal values of each byte in order. The returned
      * String will be double the length of the passed array, as it takes two characters to represent any given byte.
      *
+     * <p>All bytes identified by {@link ByteBuffer#remaining()} will be used; after this method
+     * the value {@link ByteBuffer#remaining() remaining()} will be zero.</p>
+     *
      * @param data        a byte buffer to convert to Hex characters
      * @param toLowerCase <code>true</code> converts to lowercase, <code>false</code> to uppercase
      * @return A String containing lower-case hexadecimal characters
@@ -248,13 +263,20 @@ public class Hex implements BinaryEncoder, BinaryDecoder {
         return new String(encodeHex(data, toLowerCase));
     }
 
+    /**
+     * Convert the byte buffer to a a byte array. All bytes identified by
+     * {@link ByteBuffer#remaining()} will be used.
+     *
+     * @param byteBuffer the byte buffer
+     * @return the byte[]
+     */
     private static byte[] toByteArray(final ByteBuffer byteBuffer) {
         final int remaining = byteBuffer.remaining();
         // Use the underlying buffer if possible
         if (byteBuffer.hasArray()) {
             final byte[] byteArray = byteBuffer.array();
             if (remaining == byteArray.length) {
-                //byteBuffer.position(remaining);
+                byteBuffer.position(remaining);
                 return byteArray;
             }
         }
@@ -332,6 +354,9 @@ public class Hex implements BinaryEncoder, BinaryDecoder {
      * The returned array will be half the length of the passed array, as it takes two characters to represent any given
      * byte. An exception is thrown if the passed char array has an odd number of elements.
      *
+     * <p>All bytes identified by {@link ByteBuffer#remaining()} will be used; after this method
+     * the value {@link ByteBuffer#remaining() remaining()} will be zero.</p>
+     *
      * @param buffer An array of character bytes containing hexadecimal digits
      * @return A byte array containing binary data decoded from the supplied byte array (representing characters).
      * @throws DecoderException Thrown if an odd number of characters is supplied to this function
@@ -393,10 +418,12 @@ public class Hex implements BinaryEncoder, BinaryDecoder {
      * Converts byte buffer into an array of bytes for the characters representing the hexadecimal values of each byte
      * in order. The returned array will be double the length of the passed array, as it takes two characters to
      * represent any given byte.
-     * <p>
-     * The conversion from hexadecimal characters to the returned bytes is performed with the charset named by
-     * {@link #getCharset()}.
-     * </p>
+     *
+     * <p>The conversion from hexadecimal characters to the returned bytes is performed with the charset named by
+     * {@link #getCharset()}.</p>
+     *
+     * <p>All bytes identified by {@link ByteBuffer#remaining()} will be used; after this method
+     * the value {@link ByteBuffer#remaining() remaining()} will be zero.</p>
      *
      * @param array a byte buffer to convert to Hex characters
      * @return A byte[] containing the bytes of the lower-case hexadecimal characters

--- a/src/test/java/org/apache/commons/codec/binary/HexTest.java
+++ b/src/test/java/org/apache/commons/codec/binary/HexTest.java
@@ -249,6 +249,7 @@ public class HexTest {
         // Effectively set remaining == 0 => empty
         bb.flip();
         assertTrue(Arrays.equals(new byte[0], new Hex().decode(bb)));
+        assertEquals(0, bb.remaining());
     }
 
     @Test
@@ -258,16 +259,19 @@ public class HexTest {
 
     @Test
     public void testDecodeByteBufferOddCharacters() {
-        checkDecodeHexByteBufferOddCharacters(ByteBuffer.wrap(new byte[] { 65 }));
+        final ByteBuffer bb = allocate(1);
+        bb.put((byte) 65);
+        bb.flip();
+        checkDecodeHexByteBufferOddCharacters(bb);
     }
 
     @Test
     public void testDecodeByteBufferWithLimitOddCharacters() {
-        final ByteBuffer buffer = allocate(10);
-        buffer.put(1, (byte) 65);
-        buffer.position(1);
-        buffer.limit(2);
-        checkDecodeHexByteBufferOddCharacters(buffer);
+        final ByteBuffer bb = allocate(10);
+        bb.put(1, (byte) 65);
+        bb.position(1);
+        bb.limit(2);
+        checkDecodeHexByteBufferOddCharacters(bb);
     }
 
     @Test
@@ -334,6 +338,7 @@ public class HexTest {
             bb.position(i * 2);
             bb.limit(i * 2 + 4);
             assertEquals(new String(Arrays.copyOfRange(expected, i, i + 2)), new String(new Hex().decode(bb)));
+            assertEquals(0, bb.remaining());
         }
     }
 
@@ -358,6 +363,7 @@ public class HexTest {
         // Effectively set remaining == 0 => empty
         bb.flip();
         assertTrue(Arrays.equals(new byte[0], new Hex().encode(bb)));
+        assertEquals(0, bb.remaining());
     }
 
     @Test
@@ -457,12 +463,20 @@ public class HexTest {
         final ByteBuffer b = StringUtils.getByteBufferUtf8("Hello World");
         final String expected = "48656c6c6f20576f726c64";
         char[] actual;
+        // Default lower-case
         actual = Hex.encodeHex(b);
         assertEquals(expected, new String(actual));
+        assertEquals(0, b.remaining());
+        // lower-case
+        b.flip();
         actual = Hex.encodeHex(b, true);
         assertEquals(expected, new String(actual));
+        assertEquals(0, b.remaining());
+        // upper-case
+        b.flip();
         actual = Hex.encodeHex(b, false);
-        assertFalse(expected.equals(new String(actual)));
+        assertEquals(expected.toUpperCase(), new String(actual));
+        assertEquals(0, b.remaining());
     }
 
     @Test
@@ -470,12 +484,20 @@ public class HexTest {
         final ByteBuffer b = StringUtils.getByteBufferUtf8("Hello World");
         final String expected = "48656C6C6F20576F726C64";
         char[] actual;
+        // Default lower-case
         actual = Hex.encodeHex(b);
-        assertFalse(expected.equals(new String(actual)));
+        assertEquals(expected.toLowerCase(), new String(actual));
+        assertEquals(0, b.remaining());
+        // lower-case
+        b.flip();
         actual = Hex.encodeHex(b, true);
-        assertFalse(expected.equals(new String(actual)));
+        assertEquals(expected.toLowerCase(), new String(actual));
+        assertEquals(0, b.remaining());
+        // upper-case
+        b.flip();
         actual = Hex.encodeHex(b, false);
-        assertTrue(expected.equals(new String(actual)));
+        assertEquals(expected, new String(actual));
+        assertEquals(0, b.remaining());
     }
 
     @Test
@@ -486,13 +508,18 @@ public class HexTest {
 
     @Test
     public void testEncodeHex_ByteBufferWithLimit() {
-        final ByteBuffer bb = ByteBuffer.wrap(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
+        final ByteBuffer bb = allocate(16);
+        for (int i = 0; i < 16; i++) {
+            bb.put((byte) i);
+        }
+        bb.flip();
         final String expected = "000102030405060708090a0b0c0d0e0f";
         // Test pairs of bytes
         for (int i = 0; i < 15; i++) {
             bb.position(i);
             bb.limit(i + 2);
             assertEquals(expected.substring(i * 2, i * 2 + 4), new String(Hex.encodeHex(bb)));
+            assertEquals(0, bb.remaining());
         }
     }
 
@@ -507,9 +534,11 @@ public class HexTest {
         final ByteBuffer bb = allocate(36);
         bb.limit(3);
         assertEquals("000000", Hex.encodeHexString(bb));
+        assertEquals(0, bb.remaining());
         bb.position(1);
         bb.limit(3);
         assertEquals("0000", Hex.encodeHexString(bb));
+        assertEquals(0, bb.remaining());
     }
 
     @Test
@@ -530,12 +559,18 @@ public class HexTest {
 
     @Test
     public void testEncodeHexByteString_ByteBufferBoolean_ToLowerCase() {
-        assertEquals("0a", Hex.encodeHexString(ByteBuffer.wrap(new byte[] { 10 }), true));
+        final ByteBuffer bb = allocate(1);
+        bb.put((byte) 10);
+        bb.flip();
+        assertEquals("0a", Hex.encodeHexString(bb, true));
     }
 
     @Test
     public void testEncodeHexByteString_ByteBufferBoolean_ToUpperCase() {
-        assertEquals("0A", Hex.encodeHexString(ByteBuffer.wrap(new byte[] { 10 }), false));
+        final ByteBuffer bb = allocate(1);
+        bb.put((byte) 10);
+        bb.flip();
+        assertEquals("0A", Hex.encodeHexString(bb, false));
     }
 
     @Test
@@ -545,6 +580,7 @@ public class HexTest {
         bb.position(1);
         bb.limit(2);
         assertEquals("0a", Hex.encodeHexString(bb, true));
+        assertEquals(0, bb.remaining());
     }
 
     @Test
@@ -554,6 +590,7 @@ public class HexTest {
         bb.position(1);
         bb.limit(2);
         assertEquals("0A", Hex.encodeHexString(bb, false));
+        assertEquals(0, bb.remaining());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/codec/binary/HexTest.java
+++ b/src/test/java/org/apache/commons/codec/binary/HexTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.fail;
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Arrays;
 import java.util.Random;
@@ -45,8 +46,34 @@ public class HexTest {
 
     private final static boolean LOG = false;
 
+    /**
+     * Allocate a ByteBuffer.
+     * 
+     * <p>The default implementation uses {@link ByteBuffer#allocate(int)}.
+     * The method is overridden in AllocateDirectHexTest to use
+     * {@link ByteBuffer#allocateDirect(int)}
+     *
+     * @param capacity the capacity
+     * @return the byte buffer
+     */
     protected ByteBuffer allocate(final int capacity) {
         return ByteBuffer.allocate(capacity);
+    }
+
+    /**
+     * Encodes the given string into a byte buffer using the UTF-8 charset.
+     * 
+     * <p>The buffer is allocated using {@link #allocate(int)}.
+     *
+     * @param string the String to encode
+     * @return the byte buffer
+     */
+    private ByteBuffer getByteBufferUtf8(String string) {
+        final byte[] bytes = string.getBytes(StandardCharsets.UTF_8);
+        final ByteBuffer bb = allocate(bytes.length);
+        bb.put(bytes);
+        bb.flip();
+        return bb;
     }
 
     private boolean charsetSanityCheck(final String name) {
@@ -331,7 +358,7 @@ public class HexTest {
 
     @Test
     public void testDecodeByteBufferWithLimit() throws DecoderException {
-        final ByteBuffer bb = StringUtils.getByteBufferUtf8("000102030405060708090a0b0c0d0e0f");
+        final ByteBuffer bb = getByteBufferUtf8("000102030405060708090a0b0c0d0e0f");
         final byte[] expected = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
         // Test pairs of bytes
         for (int i = 0; i < 15; i++) {
@@ -460,7 +487,7 @@ public class HexTest {
 
     @Test
     public void testEncodeHexByteBufferHelloWorldLowerCaseHex() {
-        final ByteBuffer b = StringUtils.getByteBufferUtf8("Hello World");
+        final ByteBuffer b = getByteBufferUtf8("Hello World");
         final String expected = "48656c6c6f20576f726c64";
         char[] actual;
         // Default lower-case
@@ -481,7 +508,7 @@ public class HexTest {
 
     @Test
     public void testEncodeHexByteBufferHelloWorldUpperCaseHex() {
-        final ByteBuffer b = StringUtils.getByteBufferUtf8("Hello World");
+        final ByteBuffer b = getByteBufferUtf8("Hello World");
         final String expected = "48656C6C6F20576F726C64";
         char[] actual;
         // Default lower-case

--- a/src/test/java/org/apache/commons/codec/binary/StringUtilsTest.java
+++ b/src/test/java/org/apache/commons/codec/binary/StringUtilsTest.java
@@ -18,6 +18,8 @@
 package org.apache.commons.codec.binary;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.junit.Assert;
@@ -235,5 +237,13 @@ public class StringUtilsTest {
         Assert.assertFalse(StringUtils.equals(new StringBuilder("abc"), "abcd"));
         Assert.assertFalse(StringUtils.equals("abcd", new StringBuilder("abc")));
         Assert.assertFalse(StringUtils.equals(new StringBuilder("abc"), "ABC"));
+    }
+
+    @Test
+    public void testByteBufferUtf8() {
+        Assert.assertNull("Should be null safe", StringUtils.getByteBufferUtf8(null));
+        final String text = "asdhjfhsadiogasdjhagsdygfjasfgsdaksjdhfk";
+        final ByteBuffer bb = StringUtils.getByteBufferUtf8(text);
+        Assert.assertArrayEquals(text.getBytes(StandardCharsets.UTF_8), bb.array());
     }
 }


### PR DESCRIPTION
The use of ByteBuffer.array() for any array-backed buffers means that the Hex class can produce incorrect results if the backing array is not entirely filled with the data to encode/decode.

This fixes the implementation by only using the backing array if the length is equal to the reported capacity. Otherwise the methods using ByteBuffer default to copying the remaining bytes into a copy array.

The code has been documented as using all remaining bytes in the input ByteBuffer. The methods now handle input array backed ByteBuffers and directly allocated ByteBuffers equally.

Tests have been added using limits on the buffer to encode/decode a sub-section of the bytes.

The tests have been updated so all tests are run with a direct allocated ByteBuffer in AllocateDirectHexTest.
