### PR TITLE
[CODEC-280] Added strict decoding property to BaseNCodec.

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -44,6 +44,7 @@ The <action> type attribute can be add,update,fix,remove.
 
     <release version="1.15" date="YYYY-MM-DD" description="Feature and fix release.">
       <action issue="CODEC-264" dev="aherbert" due-to="Andy Seaborne" type="fix">MurmurHash3: Ensure hash128 maintains the sign extension bug.</action>
+      <action issue="CODEC-280" dev="aherbert" type="update">Base32/64: Added strict decoding property to control handling of trailing bits. Default lenient mode discards them without error. Strict mode raise an exception.</action>
     </release>
 
     <release version="1.14" date="2019-12-30" description="Feature and fix release.">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -44,7 +44,7 @@ The <action> type attribute can be add,update,fix,remove.
 
     <release version="1.15" date="YYYY-MM-DD" description="Feature and fix release.">
       <action issue="CODEC-264" dev="aherbert" due-to="Andy Seaborne" type="fix">MurmurHash3: Ensure hash128 maintains the sign extension bug.</action>
-      <action issue="CODEC-280" dev="aherbert" type="update">Base32/64: Added strict decoding property to control handling of trailing bits. Default lenient mode discards them without error. Strict mode raise an exception.</action>
+      <action issue="CODEC-280" dev="aherbert" type="update">Base32/Base64/BCodec: Added strict decoding property to control handling of trailing bits. Default lenient mode discards them without error. Strict mode raise an exception.</action>
     </release>
 
     <release version="1.14" date="2019-12-30" description="Feature and fix release.">

--- a/src/main/java/org/apache/commons/codec/binary/BaseNCodec.java
+++ b/src/main/java/org/apache/commons/codec/binary/BaseNCodec.java
@@ -231,7 +231,7 @@ public abstract class BaseNCodec implements BinaryEncoder, BinaryDecoder {
     }
 
     /**
-     * Sets the decoding behaviour when the input bytes contain leftover trailing bits that 
+     * Sets the decoding behaviour when the input bytes contain leftover trailing bits that
      * cannot be created by a valid encoding. These can be bits that are unused from the final
      * character or entire characters. The default mode is lenient decoding. Set this to
      * {@code true} to enable strict decoding.
@@ -242,7 +242,7 @@ public abstract class BaseNCodec implements BinaryEncoder, BinaryDecoder {
      *     are not part of a valid encoding. Any unused bits from the final character must
      *     be zero. Impossible counts of entire final characters are not allowed.
      * </ul>
-     * 
+     *
      * <p>When strict decoding is enabled it is expected that the decoded bytes will be re-encoded
      * to a byte array that matches the original, i.e. no changes occur on the final
      * character. This requires that the input bytes use the same padding and alphabet

--- a/src/main/java/org/apache/commons/codec/binary/BaseNCodec.java
+++ b/src/main/java/org/apache/commons/codec/binary/BaseNCodec.java
@@ -23,6 +23,7 @@ import org.apache.commons.codec.BinaryDecoder;
 import org.apache.commons.codec.BinaryEncoder;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.EncoderException;
+import org.apache.commons.codec.binary.BaseNCodec.Context;
 
 /**
  * Abstract superclass for Base-N encoders and decoders.
@@ -191,6 +192,12 @@ public abstract class BaseNCodec implements BinaryEncoder, BinaryDecoder {
     private final int chunkSeparatorLength;
 
     /**
+     * If true then decoding should throw an exception for impossible combinations of bits at the
+     * end of the byte input. The default is to decode as much of them as possible.
+     */
+    private boolean strictDecoding;
+
+    /**
      * Note {@code lineLength} is rounded down to the nearest multiple of the encoded block size.
      * If {@code chunkSeparatorLength} is zero, then chunking is disabled.
      * @param unencodedBlockSize the size of an unencoded block (e.g. Base64 = 3)
@@ -221,6 +228,47 @@ public abstract class BaseNCodec implements BinaryEncoder, BinaryDecoder {
         this.chunkSeparatorLength = chunkSeparatorLength;
 
         this.pad = pad;
+    }
+
+    /**
+     * Sets the decoding behaviour when the input bytes contain leftover trailing bits that 
+     * cannot be created by a valid encoding. These can be bits that are unused from the final
+     * character or entire characters. The default mode is lenient decoding. Set this to
+     * {@code true} to enable strict decoding.
+     * <ul>
+     * <li>Lenient: Any trailing bits are composed into 8-bit bytes where possible.
+     *     The remainder are discarded.
+     * <li>Strict: The decoding will raise an {@link IllegalArgumentException} if trailing bits
+     *     are not part of a valid encoding. Any unused bits from the final character must
+     *     be zero. Impossible counts of entire final characters are not allowed.
+     * </ul>
+     * 
+     * <p>When strict decoding is enabled it is expected that the decoded bytes will be re-encoded
+     * to a byte array that matches the original, i.e. no changes occur on the final
+     * character. This requires that the input bytes use the same padding and alphabet
+     * as the encoder.
+     *
+     * @param strictDecoding Set to true to enable strict decoding; otherwise use lenient decoding.
+     * @see #encode(byte[])
+     * @since 1.15
+     */
+    public void setStrictDecoding(boolean strictDecoding) {
+        this.strictDecoding = strictDecoding;
+    }
+
+    /**
+     * Returns true if decoding behaviour is strict. Decoding will raise an
+     * {@link IllegalArgumentException} if trailing bits are not part of a valid encoding.
+     *
+     * <p>The default is false for lenient encoding. Decoding will compose trailing bits
+     * into 8-bit bytes and discard the remainder.
+     *
+     * @return true if using strict decoding
+     * @see #setStrictDecoding(boolean)
+     * @since 1.15
+     */
+    public boolean isStrictDecoding() {
+        return strictDecoding;
     }
 
     /**

--- a/src/test/java/org/apache/commons/codec/net/BCodecTest.java
+++ b/src/test/java/org/apache/commons/codec/net/BCodecTest.java
@@ -26,6 +26,7 @@ import java.nio.charset.UnsupportedCharsetException;
 import org.apache.commons.codec.CharEncoding;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.EncoderException;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -157,6 +158,7 @@ public class BCodecTest {
     }
 
     @Test
+    @Ignore("CODEC-280: Disabled strict decoding by default. The BCodec uses the default so this test does not fail the impossible cases.")
     public void testBase64ImpossibleSamples() {
         final BCodec codec = new BCodec();
         for (final String s : BASE64_IMPOSSIBLE_CASES) {

--- a/src/test/java/org/apache/commons/codec/net/BCodecTest.java
+++ b/src/test/java/org/apache/commons/codec/net/BCodecTest.java
@@ -27,7 +27,6 @@ import org.apache.commons.codec.CharEncoding;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.EncoderException;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**

--- a/src/test/java/org/apache/commons/codec/net/BCodecTest.java
+++ b/src/test/java/org/apache/commons/codec/net/BCodecTest.java
@@ -26,6 +26,7 @@ import java.nio.charset.UnsupportedCharsetException;
 import org.apache.commons.codec.CharEncoding;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.EncoderException;
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -158,13 +159,20 @@ public class BCodecTest {
     }
 
     @Test
-    @Ignore("CODEC-280: Disabled strict decoding by default. The BCodec uses the default so this test does not fail the impossible cases.")
-    public void testBase64ImpossibleSamples() {
+    public void testBase64ImpossibleSamples() throws DecoderException {
         final BCodec codec = new BCodec();
+        // Default encoding is lenient
+        Assert.assertFalse(codec.isStrictDecoding());
+        for (final String s : BASE64_IMPOSSIBLE_CASES) {
+            codec.decode(s);
+        }
+        // Use strict mode to prevent impossible cases
+        codec.setStrictDecoding(true);
+        Assert.assertTrue(codec.isStrictDecoding());
         for (final String s : BASE64_IMPOSSIBLE_CASES) {
             try {
                 codec.decode(s);
-                fail();
+                fail("Expected an exception for impossible case");
             } catch (final DecoderException ex) {
                 // expected
             }


### PR DESCRIPTION
The default is lenient encoding. Any trailing bits that cannot be
interpreted as part of the encoding are discarded. Combinations of
trailing characters that cannot be created by a valid encoding are
partially interpreted.

If set to strict encoding the codec will raise an exception when
trailing bits are present that are not part of a valid encoding.

Added tests to show that in lenient mode re-encoding will create a
different byte array.

In strict mode the re-encoding should create the same byte array as the
original (with appropriate pad characters on the input).

The PR does not current address behaviour of BCodec class that uses Base64. The test that validates input that requires strict mode have been disabled to allow travis to pass.