### PR TITLE
CODEC-281: Double metaphone  encode kc as K

### DIFF
--- a/src/main/java/org/apache/commons/codec/language/DoubleMetaphone.java
+++ b/src/main/java/org/apache/commons/codec/language/DoubleMetaphone.java
@@ -132,8 +132,7 @@ public class DoubleMetaphone implements StringEncoder {
                 index = handleJ(value, result, index, slavoGermanic);
                 break;
             case 'K':
-                result.append('K');
-                index = charAt(value, index + 1) == 'K' ? index + 2 : index + 1;
+                index = handleK(value, result, index);
                 break;
             case 'L':
                 index = handleL(value, result, index);
@@ -540,6 +539,25 @@ public class DoubleMetaphone implements StringEncoder {
                     index++;
                 }
             }
+        return index;
+    }
+
+    /**
+     * Handles 'K' cases.
+     */
+    private int handleK(final String value, final DoubleMetaphoneResult result, int index) {
+        result.append('K');
+        if (charAt(value, index + 1) == 'K') {
+            index += 2;
+        } else if ((charAt(value, index + 1) == 'C')) { //-- in "Kirkcaldy", "kc" should be encoded "K" instead of "KK" --//
+            final DoubleMetaphoneResult nextCharResult = new DoubleMetaphoneResult(this.getMaxCodeLen());
+            int nextCharIndex = handleC(value, nextCharResult, index + 1);
+            if (nextCharResult.getPrimary().equals("K")) {
+                index = nextCharIndex;
+            }
+        } else {
+            index++;
+        }
         return index;
     }
 

--- a/src/test/java/org/apache/commons/codec/language/DoubleMetaphone2Test.java
+++ b/src/test/java/org/apache/commons/codec/language/DoubleMetaphone2Test.java
@@ -512,6 +512,7 @@ public class DoubleMetaphone2Test extends StringEncoderAbstractTest<DoubleMetaph
         {"King", "KNK", "KNK"},
         {"Kinsey", "KNS", "KNS"},
         {"Kirk", "KRK", "KRK"},
+        {"Kirkcaldy", "KRKL", "KRKL"},
         {"Kirton", "KRTN", "KRTN"},
         {"Kistler", "KSTL", "KSTL"},
         {"Kitchen", "KXN", "KXN"},


### PR DESCRIPTION
**Double metaphone should handle 'K' for 'kc' entries instead of 'KK'**

One example is Kir***kc***aldy: which is presently encoded as "KR***KK***".

When omitting 'k' or 'c' letters (for example, Kircaldy or Kirkaldy) it is encoded as "KRKL".

The correction consists to verify when letter 'c' follows 'k', if 'c' is encoded as 'K', it is ignored as for a succession of 'kk' letters. With this correction, Kirkcaldy would be encoded as "KRKL" which is more discriminant and compliant with the phonetic.