### PR TITLE
CODEC-286 upgrade to commons-lang v3.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,8 +226,7 @@ limitations under the License.
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <!-- 3.9+ needs Java8 -->
-      <version>3.8</version>
+      <version>3.9</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Handles https://issues.apache.org/jira/browse/CODEC-286

I understand it needs to also bump java to v1.8, but that should probably be done soon.

I work on java 1.6, 1.7, 1.8 and 11 projects at work, for the 1.6 and 1.7 projects we have no intension of upgrading and if we needed new commons-codec for new features or bug fixes, it would force us to upgrade which is probably a good thing.