### PR TITLE
CODEC-285 Better StringEncoderAbstractTest testEncodeNull

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,9 @@ limitations under the License.
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <!-- Fix to build on JDK 7: version 4.0.0 requires Java 8. -->
+    <!-- Can be dropped when CP 49 is released -->
+    <commons.felix.version>3.5.1</commons.felix.version>
     <commons.componentid>codec</commons.componentid>
     <commons.module.name>org.apache.commons.codec</commons.module.name>
     <commons.jira.id>CODEC</commons.jira.id>

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,18 @@ limitations under the License.
       <version>2.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.6.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>5.6.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -236,11 +236,23 @@ limitations under the License.
       <artifactId>junit</artifactId>
       <version>4.13.2</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.12.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>2.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -230,19 +230,24 @@ limitations under the License.
     </contributor>
   </contributors>
   <!-- Codec only has test dependencies ATM -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.8.2</version>
+        <type>pom</type>
+        <scope>import</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-core</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
@@ -258,13 +263,11 @@ limitations under the License.
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.6.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
-      <version>5.6.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/org/apache/commons/codec/StringEncoderAbstractTest.java
+++ b/src/test/java/org/apache/commons/codec/StringEncoderAbstractTest.java
@@ -21,6 +21,12 @@ import java.util.Locale;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  */
@@ -59,13 +65,9 @@ public abstract class StringEncoderAbstractTest<T extends StringEncoder> {
     }
 
     @Test
-    public void testEncodeNull() throws Exception {
+    public void testEncodeNull() throws EncoderException {
         final StringEncoder encoder = this.getStringEncoder();
-        try {
-            encoder.encode(null);
-        } catch (final EncoderException ee) {
-            // An exception should be thrown
-        }
+        encoder.encode(null);
     }
 
     @Test


### PR DESCRIPTION
Follow up for PR https://github.com/apache/commons-codec/pull/39

From experience people write tests that don't check exceptions correctly, either they are not thrown, or a different than expected line throws that exception, or it's the wrong exception, or wrong message.

This test doesn't ever throw the exception listed, so why is it catching and ignoring if thrown???