### PR TITLE
CODEC-285 Base32InputStreamTest testReadOutOfBounds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,9 @@ limitations under the License.
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <!-- Fix to build on JDK 7: version 4.0.0 requires Java 8. -->
+    <!-- Can be dropped when CP 49 is released -->
+    <commons.felix.version>3.5.1</commons.felix.version>
     <commons.componentid>codec</commons.componentid>
     <commons.module.name>org.apache.commons.codec</commons.module.name>
     <commons.jira.id>CODEC</commons.jira.id>

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,18 @@ limitations under the License.
       <version>2.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.6.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>5.6.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -236,11 +236,23 @@ limitations under the License.
       <artifactId>junit</artifactId>
       <version>4.13.2</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.12.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>2.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -230,19 +230,24 @@ limitations under the License.
     </contributor>
   </contributors>
   <!-- Codec only has test dependencies ATM -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.8.2</version>
+        <type>pom</type>
+        <scope>import</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-core</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
@@ -258,13 +263,11 @@ limitations under the License.
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.6.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
-      <version>5.6.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/org/apache/commons/codec/binary/Base32InputStreamTest.java
+++ b/src/test/java/org/apache/commons/codec/binary/Base32InputStreamTest.java
@@ -24,12 +24,19 @@ import java.io.InputStream;
 
 import org.apache.commons.codec.CodecPolicy;
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
 
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class Base32InputStreamTest {
 
@@ -442,33 +449,32 @@ public class Base32InputStreamTest {
         final ByteArrayInputStream bin = new ByteArrayInputStream(decoded);
         try (final Base32InputStream in = new Base32InputStream(bin, true, 4, new byte[] { 0, 0, 0 })) {
 
-            try {
-                in.read(buf, -1, 0);
-                fail("Expected Base32InputStream.read(buf, -1, 0) to throw IndexOutOfBoundsException");
-            } catch (final IndexOutOfBoundsException e) {
-                // Expected
-            }
-
-            try {
-                in.read(buf, 0, -1);
-                fail("Expected Base32InputStream.read(buf, 0, -1) to throw IndexOutOfBoundsException");
-            } catch (final IndexOutOfBoundsException e) {
-                // Expected
-            }
-
-            try {
-                in.read(buf, buf.length + 1, 0);
-                fail("Base32InputStream.read(buf, buf.length + 1, 0) throws IndexOutOfBoundsException");
-            } catch (final IndexOutOfBoundsException e) {
-                // Expected
-            }
-
-            try {
-                in.read(buf, buf.length - 1, 2);
-                fail("Base32InputStream.read(buf, buf.length - 1, 2) throws IndexOutOfBoundsException");
-            } catch (final IndexOutOfBoundsException e) {
-                // Expected
-            }
+            assertAll(
+                    () -> {
+                        final Executable testMethod = () -> in.read(buf, -1, 0);
+                        final String message = "Expected Base32InputStream.read(buf, -1, 0) to throw IndexOutOfBoundsException";
+                        final IndexOutOfBoundsException thrown = assertThrows(IndexOutOfBoundsException.class, testMethod, message);
+                        assertThat(message, thrown.getMessage(), is(nullValue()));
+                    },
+                    () -> {
+                        final Executable testMethod = () -> in.read(buf, 0, -1);
+                        final String message = "Expected Base32InputStream.read(buf, 0, -1) to throw IndexOutOfBoundsException";
+                        final IndexOutOfBoundsException thrown = assertThrows(IndexOutOfBoundsException.class, testMethod, message);
+                        assertThat(message, thrown.getMessage(), is(nullValue()));
+                    },
+                    () -> {
+                        final Executable testMethod = () -> in.read(buf, buf.length + 1, 0);
+                        final String message = "Base32InputStream.read(buf, buf.length + 1, 0) throws IndexOutOfBoundsException";
+                        final IndexOutOfBoundsException thrown = assertThrows(IndexOutOfBoundsException.class, testMethod, message);
+                        assertThat(message, thrown.getMessage(), is(nullValue()));
+                    },
+                    () -> {
+                        final Executable testMethod = () -> in.read(buf, buf.length - 1, 2);
+                        final String message = "Base32InputStream.read(buf, buf.length - 1, 2) throws IndexOutOfBoundsException";
+                        final IndexOutOfBoundsException thrown = assertThrows(IndexOutOfBoundsException.class, testMethod, message);
+                        assertThat(message, thrown.getMessage(), is(nullValue()));
+                    }
+            );
         }
     }
 


### PR DESCRIPTION
Follow up for PR https://github.com/apache/commons-codec/pull/39

From experience people write tests that don't check exceptions correctly, either they are not thrown, or a different than expected line throws that exception, or it's the wrong exception, or wrong message.

Using assertAll and assertThrows to explicitly check the expected line throws the expected exception, and all done in parallel not sequentially.