### PR TITLE
Add form feed and vertical tab whitespace to isWhiteSpace()

### DIFF
--- a/src/main/java/org/apache/commons/codec/binary/BaseNCodec.java
+++ b/src/main/java/org/apache/commons/codec/binary/BaseNCodec.java
@@ -261,6 +261,9 @@ public abstract class BaseNCodec implements BinaryEncoder, BinaryDecoder {
             case '\n' :
             case '\r' :
             case '\t' :
+            case '\f' :
+            // Vertical tab character
+            case '\u000B' :
                 return true;
             default :
                 return false;

--- a/src/test/java/org/apache/commons/codec/binary/BaseNCodecTest.java
+++ b/src/test/java/org/apache/commons/codec/binary/BaseNCodecTest.java
@@ -108,6 +108,8 @@ public class BaseNCodecTest {
         assertTrue(BaseNCodec.isWhiteSpace((byte) '\n'));
         assertTrue(BaseNCodec.isWhiteSpace((byte) '\r'));
         assertTrue(BaseNCodec.isWhiteSpace((byte) '\t'));
+        assertTrue(BaseNCodec.isWhiteSpace((byte) '\f'));
+        assertTrue(BaseNCodec.isWhiteSpace((byte) '\u000B'));
     }
 //
 //    @Test


### PR DESCRIPTION
Ran into an issue with these characters not being detected and having false positive `isBase64()` detection as a result - would be good to get them counted as whitespace.

Ref. C/C++ `isspace()` function considers these characters as whitespace.
http://www.cplusplus.com/reference/cctype/isspace/
https://www.oreilly.com/library/view/c-in-a/0596006977/re129.html

Cheers!