### PR TITLE
CODEC-249 - Incorrect transform of CH digraph according basic rules

### DIFF
--- a/src/main/java/org/apache/commons/codec/language/Metaphone.java
+++ b/src/main/java/org/apache/commons/codec/language/Metaphone.java
@@ -189,7 +189,7 @@ public class Metaphone implements StringEncoder {
                         break;
                     }
                     if (isNextChar(local, n, 'H')) { // detect CH
-                        if (n == 0 &&
+                        if (n > 0 &&
                             wdsz >= 3 &&
                             isVowel(local,2) ) { // CH consonant -> K consonant
                             code.append('K');

--- a/src/test/java/org/apache/commons/codec/language/MetaphoneTest.java
+++ b/src/test/java/org/apache/commons/codec/language/MetaphoneTest.java
@@ -405,8 +405,10 @@ public class MetaphoneTest extends StringEncoderAbstractTest<Metaphone> {
         assertEquals( "SKTL", this.getStringEncoder().metaphone("SCHEDULE") );
         assertEquals( "SKMT", this.getStringEncoder().metaphone("SCHEMATIC") );
 
-        assertEquals( "KRKT", this.getStringEncoder().metaphone("CHARACTER") );
+        assertEquals( "XRKTR", this.getStringEncoder().metaphone("CHARACTER") );
         assertEquals( "TX", this.getStringEncoder().metaphone("TEACH") );
+
+        assertEquals("XR", this.getStringEncoder().metaphone("CHERI"));
     }
 
     @Test


### PR DESCRIPTION
Error Metaphone when the word start with "CH"

CHERI should be transformed to 'XR' but I get 'KR' which is wrong