### PR TITLE
CODEC-301: BaseNCodec: Reduce byte[] allocations by reusing buffers

### DIFF
--- a/src/main/java/org/apache/commons/codec/binary/BaseNCodec.java
+++ b/src/main/java/org/apache/commons/codec/binary/BaseNCodec.java
@@ -394,7 +394,7 @@ public abstract class BaseNCodec implements BinaryEncoder, BinaryDecoder {
      * @return The amount of buffered data available for reading.
      */
     int available(final Context context) {  // package protected for access from I/O streams
-        return context.buffer != null ? context.pos - context.readPos : 0;
+        return hasData(context) ? context.pos - context.readPos : 0;
     }
 
     /**
@@ -632,7 +632,7 @@ public abstract class BaseNCodec implements BinaryEncoder, BinaryDecoder {
      * @return true if there is data still available for reading.
      */
     boolean hasData(final Context context) {  // package protected for access from I/O streams
-        return context.buffer != null;
+        return context.pos > context.readPos;
     }
 
     /**
@@ -711,12 +711,16 @@ public abstract class BaseNCodec implements BinaryEncoder, BinaryDecoder {
      * @return The number of bytes successfully extracted into the provided byte[] array.
      */
     int readResults(final byte[] b, final int bPos, final int bAvail, final Context context) {
-        if (context.buffer != null) {
+        if (hasData(context)) {
             final int len = Math.min(available(context), bAvail);
             System.arraycopy(context.buffer, context.readPos, b, bPos, len);
             context.readPos += len;
-            if (context.readPos >= context.pos) {
-                context.buffer = null; // so hasData() will return false, and this method can return -1
+            if (!hasData(context)) {
+                // All data read.
+                // Reset position markers but do not set buffer to null to allow its reuse.
+                // hasData(context) will still return false, and this method will return 0 until
+                // more data is available, or -1 if EOF.
+                context.pos = context.readPos = 0;
             }
             return len;
         }

--- a/src/test/java/org/apache/commons/codec/binary/Base64InputStreamTest.java
+++ b/src/test/java/org/apache/commons/codec/binary/Base64InputStreamTest.java
@@ -409,6 +409,30 @@ public class Base64InputStreamTest {
     }
 
     /**
+     * Tests read using different buffer sizes
+     *
+     * @throws Exception
+     *             for some failure scenarios.
+     */
+    @Test
+    public void testReadMultipleBufferSizes() throws Exception {
+        final byte[][] randomData = BaseNTestData.randomData(new Base64(0, null, false), 1024 * 64);
+        byte[] encoded = randomData[1];
+        byte[] decoded = randomData[0];
+        final ByteArrayInputStream bin = new ByteArrayInputStream(encoded);
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (final Base64InputStream in = new Base64InputStream(bin)) {
+            for (int i : new int[] { 4 * 1024, 4 * 1024, 8 * 1024, 8 * 1024, 16 * 1024, 16 * 1024, 8 * 1024 }) {
+                final byte[] buf = new byte[i];
+                int bytesRead = in.read(buf);
+                assertEquals(i, bytesRead);
+                out.write(buf, 0, bytesRead);
+            }
+        }
+        assertArrayEquals(decoded, out.toByteArray());
+    }
+
+    /**
      * Tests read returning 0
      *
      * @throws Exception


### PR DESCRIPTION
Reduces byte[] allocations from 280MB to <4MB when reading a 133MB base64 stream. 

Messured with JFR, see https://github.com/apinske/playground-io.