### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ cache:
   directories:
     - $HOME/.m2
 matrix:
+  fast_finish: true
   include:
     - jdk: openjdk8
     - jdk: openjdk11


### PR DESCRIPTION

According to the official document [Fast Finishing](https://docs.travis-ci.com/user/build-matrix/#fast-finishing), if some rows in the build matrix are allowed to fail, we can add fast_finish: true to the .travis.yml to get faster feedbacks.

If there are any inappropriate modifications in this PR, please give me feedback and I will change them.
