### PR TITLE
Avoid inefficient usage of arraylist

### DIFF
--- a/src/main/java/org/apache/commons/codec/language/bm/Lang.java
+++ b/src/main/java/org/apache/commons/codec/language/bm/Lang.java
@@ -18,6 +18,7 @@
 package org.apache.commons.codec.language.bm;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -127,7 +128,7 @@ public class Lang {
      * @return a Lang encapsulating the loaded language-guessing rules.
      */
     public static Lang loadFromResource(final String languageRulesResourceName, final Languages languages) {
-        final List<LangRule> rules = new ArrayList<>();
+        final List<LangRule> rules = new LinkedList<>();
         try (final Scanner scanner = new Scanner(Resources.getInputStream(languageRulesResourceName),
                 ResourceConstants.ENCODING)) {
             boolean inExtendedComment = false;

--- a/src/main/java/org/apache/commons/codec/language/bm/PhoneticEngine.java
+++ b/src/main/java/org/apache/commons/codec/language/bm/PhoneticEngine.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.codec.language.bm;
 
+import java.util.LinkedList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -420,7 +421,7 @@ public class PhoneticEngine {
         }
 
         final List<String> words = Arrays.asList(input.split("\\s+"));
-        final List<String> words2 = new ArrayList<>();
+        final List<String> words2 = new LinkedList<>();
 
         // special-case handling of word prefixes based upon the name type
         switch (this.nameType) {

--- a/src/main/java/org/apache/commons/codec/language/bm/Rule.java
+++ b/src/main/java/org/apache/commons/codec/language/bm/Rule.java
@@ -18,6 +18,7 @@
 package org.apache.commons.codec.language.bm;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -295,7 +296,7 @@ public class Rule {
     public static List<Rule> getInstance(final NameType nameType, final RuleType rt,
                                          final Languages.LanguageSet langs) {
         final Map<String, List<Rule>> ruleMap = getInstanceMap(nameType, rt, langs);
-        final List<Rule> allRules = new ArrayList<>();
+        final List<Rule> allRules = new LinkedList<>();
         for (final List<Rule> rules : ruleMap.values()) {
             allRules.addAll(rules);
         }


### PR DESCRIPTION
Hi,
We find that there are three ArrayList objects which are not manipulated by random access. Due to the memory reallocation triggered in the successive insertions, the time complexity of add method of ArrayList is amortized O(1). We notice that these objects are only used for traversal and the retrieval for the first or the last element.

This functionality can be implemented by LinkedList. Moreover, the insertion of LinkedList is strictly O(1) time complexity because no memory reallocation occurs.

We discovered this inefficient usage of containers by our tool Ditto. The patch is submitted. Could you please check and accept it? We have tested the patch on our PC. The patched program works well.

Bests

Ditto