### PR TITLE
Remove redundant operations.

### DIFF
--- a/src/main/java/org/apache/commons/codec/language/DaitchMokotoffSoundex.java
+++ b/src/main/java/org/apache/commons/codec/language/DaitchMokotoffSoundex.java
@@ -494,9 +494,6 @@ public class DaitchMokotoffSoundex implements StringEncoder {
 
             for (final Rule rule : rules) {
                 if (rule.matches(inputContext)) {
-                    if (branching) {
-                        nextBranches.clear();
-                    }
                     final String[] replacements = rule.getReplacements(inputContext, lastChar == '\0');
                     final boolean branchingRequired = replacements.length > 1 && branching;
 


### PR DESCRIPTION
Remove redundant operations. Clear operations on empty collections have no effect and can be removed.