### PR TITLE
CODEC-308: change NYSIIS encoding to not remove the first character i…

### DIFF
--- a/src/main/java/org/apache/commons/codec/language/Nysiis.java
+++ b/src/main/java/org/apache/commons/codec/language/Nysiis.java
@@ -275,7 +275,8 @@ public class Nysiis implements StringEncoder {
 
         // First character of key = first character of name.
         final StringBuilder key = new StringBuilder(str.length());
-        key.append(str.charAt(0));
+        final char firstChar = str.charAt(0);
+        key.append(firstChar);
 
         // Transcode remaining characters, incrementing by one character each time
         final char[] chars = str.toCharArray();
@@ -313,6 +314,12 @@ public class Nysiis implements StringEncoder {
             // If last character is A, remove it.
             if (lastChar == 'A') {
                 key.deleteCharAt(key.length() - 1);
+            }
+
+            if(key.length()==0){
+                // We've removed the first character of the string. Likely because it was an S or A
+                // We should return at least the first character
+                key.append(firstChar);
             }
         }
 

--- a/src/main/java/org/apache/commons/codec/language/Nysiis.java
+++ b/src/main/java/org/apache/commons/codec/language/Nysiis.java
@@ -316,7 +316,7 @@ public class Nysiis implements StringEncoder {
                 key.deleteCharAt(key.length() - 1);
             }
 
-            if(key.length()==0){
+            if (key.length() == 0) {
                 // We've removed the first character of the string. Likely because it was an S or A
                 // We should return at least the first character
                 key.append(firstChar);

--- a/src/main/java/org/apache/commons/codec/language/Nysiis.java
+++ b/src/main/java/org/apache/commons/codec/language/Nysiis.java
@@ -308,7 +308,7 @@ public class Nysiis implements StringEncoder {
                 key.deleteCharAt(key.length() - 1);
             }
 
-            if(key.length()==0){
+            if (key.length() == 0) {
                 // We've removed the first character of the string. Likely because it was an S or A
                 // We should return at least the first character
                 key.append(firstChar);

--- a/src/main/java/org/apache/commons/codec/language/Nysiis.java
+++ b/src/main/java/org/apache/commons/codec/language/Nysiis.java
@@ -267,7 +267,8 @@ public class Nysiis implements StringEncoder {
 
         // First character of key = first character of name.
         final StringBuilder key = new StringBuilder(str.length());
-        key.append(str.charAt(0));
+        final char firstChar = str.charAt(0);
+        key.append(firstChar);
 
         // Transcode remaining characters, incrementing by one character each time
         final char[] chars = str.toCharArray();
@@ -305,6 +306,12 @@ public class Nysiis implements StringEncoder {
             // If last character is A, remove it.
             if (lastChar == 'A') {
                 key.deleteCharAt(key.length() - 1);
+            }
+
+            if(key.length()==0){
+                // We've removed the first character of the string. Likely because it was an S or A
+                // We should return at least the first character
+                key.append(firstChar);
             }
         }
 

--- a/src/test/java/org/apache/commons/codec/language/NysiisTest.java
+++ b/src/test/java/org/apache/commons/codec/language/NysiisTest.java
@@ -140,7 +140,8 @@ public class NysiisTest extends StringEncoderAbstractTest<Nysiis> {
                 new String[] { "JILES", "JAL" },
                 // violates 6: if the last two characters are AY, remove A
                 new String[] { "CARRAWAY", "CARY" },       // Original: CARAY
-                new String[] { "YAMADA", "YANAD" });
+                new String[] { "YAMADA", "YANAD" },
+                new String[] { "ASH", "A"});
     }
 
     @Test

--- a/src/test/java/org/apache/commons/codec/language/NysiisTest.java
+++ b/src/test/java/org/apache/commons/codec/language/NysiisTest.java
@@ -136,7 +136,8 @@ class NysiisTest extends AbstractStringEncoderTest<Nysiis> {
                 new String[] { "JILES", "JAL" },
                 // violates 6: if the last two characters are AY, remove A
                 new String[] { "CARRAWAY", "CARY" },       // Original: CARAY
-                new String[] { "YAMADA", "YANAD" });
+                new String[] { "YAMADA", "YANAD" },
+                new String[] { "ASH", "A"});
     }
 
     @Test

--- a/src/test/java/org/apache/commons/codec/language/NysiisTest.java
+++ b/src/test/java/org/apache/commons/codec/language/NysiisTest.java
@@ -17,11 +17,11 @@
 
 package org.apache.commons.codec.language;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.apache.commons.codec.AbstractStringEncoderTest;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests {@link Nysiis}
@@ -137,7 +137,8 @@ class NysiisTest extends AbstractStringEncoderTest<Nysiis> {
                 // violates 6: if the last two characters are AY, remove A
                 new String[] { "CARRAWAY", "CARY" },       // Original: CARAY
                 new String[] { "YAMADA", "YANAD" },
-                new String[] { "ASH", "A"});
+                new String[] { "ASH", "A"},
+                new String[] { "SSH", "S"});
     }
 
     @Test


### PR DESCRIPTION
With the current implementation of NYSIIS, it is possible to incorrectly remove the first character from the encoding. 

According to the algorithm the first character of the string should be the first character of the encoding, then based on a bunch of other rules are applied to the string characters are removed. The implementation in commons-codec passes the entire string into the transcodeRemaining method which works for the most part and then afterwards, checks that there is at least 1 character before removing the final 'A' or 'S'. 

The problem is, if you have a word like "ASH" you will end up with a single final character of "A". Similarly with "SSH" you would have "S" and the logic will currently remove it and return a blank string when it should still return at least the first letter of the original string.