### PR TITLE
feat: Md5Crypt.md5Crypt should not fill zero to keyBytes

### DIFF
--- a/src/main/java/org/apache/commons/codec/digest/Md5Crypt.java
+++ b/src/main/java/org/apache/commons/codec/digest/Md5Crypt.java
@@ -397,7 +397,7 @@ public class Md5Crypt {
         // Is there a better way to do this with the JVM?
         ctx.reset();
         ctx1.reset();
-        Arrays.fill(keyBytes, (byte) 0);
+
         Arrays.fill(saltBytes, (byte) 0);
         Arrays.fill(finalb, (byte) 0);
 

--- a/src/test/java/org/apache/commons/codec/digest/Md5CryptTest.java
+++ b/src/test/java/org/apache/commons/codec/digest/Md5CryptTest.java
@@ -83,4 +83,12 @@ public class Md5CryptTest {
     public void testMd5CryptWithEmptySalt() {
         assertThrows(IllegalArgumentException.class, () -> Md5Crypt.md5Crypt("secret".getBytes(), ""));
     }
+
+    @Test
+    public void testMd5Crypt() {
+        final String rawText = "1234567890";
+        final byte[] rawKeyBytes = rawText.getBytes();
+        Md5Crypt.md5Crypt(rawKeyBytes);
+        assertEquals(rawText, new String(rawKeyBytes));
+    }
 }


### PR DESCRIPTION
As a pure function, parameter values ​​should not be modified inside the function - Md5Crypt.md5Crypt.