### PR TITLE
CODEC-311: Fix possible ArrayIndexOutOfBoundException thrown by RefinedSoundex.getMappingCode()

### DIFF
--- a/src/main/java/org/apache/commons/codec/language/RefinedSoundex.java
+++ b/src/main/java/org/apache/commons/codec/language/RefinedSoundex.java
@@ -173,7 +173,11 @@ public class RefinedSoundex implements StringEncoder {
         if (!Character.isLetter(c)) {
             return 0;
         }
-        return this.soundexMapping[Character.toUpperCase(c) - 'A'];
+        int index = Character.toUpperCase(c) - 'A';
+        if (index < 0 || index >= this.soundexMapping.length) {
+            return 0;
+        }
+        return this.soundexMapping[index];
     }
 
     /**

--- a/src/main/java/org/apache/commons/codec/language/RefinedSoundex.java
+++ b/src/main/java/org/apache/commons/codec/language/RefinedSoundex.java
@@ -173,7 +173,7 @@ public class RefinedSoundex implements StringEncoder {
         if (!Character.isLetter(c)) {
             return 0;
         }
-        int index = Character.toUpperCase(c) - 'A';
+        final int index = Character.toUpperCase(c) - 'A';
         if (index < 0 || index >= this.soundexMapping.length) {
             return 0;
         }

--- a/src/test/java/org/apache/commons/codec/language/RefinedSoundexTest.java
+++ b/src/test/java/org/apache/commons/codec/language/RefinedSoundexTest.java
@@ -80,6 +80,16 @@ public class RefinedSoundexTest extends AbstractStringEncoderTest<RefinedSoundex
     }
 
     @Test
+    public void testInvalidSoundexCharacter() {
+        final char[] invalid = new char[256];
+        for (int i = 0; i < invalid.length; i++) {
+            invalid[i] = (char)i;
+        }
+
+        assertEquals(new RefinedSoundex().encode(new String(invalid)), "A0136024043780159360205050136024043780159360205053");
+    }
+
+    @Test
     public void testNewInstance() {
         assertEquals("D6043", new RefinedSoundex().soundex("dogs"));
     }


### PR DESCRIPTION
This fixes a possible ArrayIndexOutOfBoundException in [src/main/java/org/apache/commons/codec/language/RefinedSoundex.java](https://github.com/apache/commons-codec/blob/master/src/main/java/org/apache/commons/codec/language/RefinedSoundex.java) thrown by `RefinedSoundex.getMappingCode()` method when handling out of range letters.

This PR adds a conditional checking to ensure the index is never out of bounds from the configured soundexMapping array. If the calculated index goes out of bounds, it will simply return 0, just like the original logic when Character.isLetter() returns false.

We found this bug using fuzzing by way of OSS-Fuzz. It is reported at https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64353.