### PR TITLE
CODEC-312: Fix possible StringIndexOutOfBoundException thrown by MatchRatingApproachEncoder.encode() method

### DIFF
--- a/src/main/java/org/apache/commons/codec/language/MatchRatingApproachEncoder.java
+++ b/src/main/java/org/apache/commons/codec/language/MatchRatingApproachEncoder.java
@@ -126,9 +126,19 @@ public class MatchRatingApproachEncoder implements StringEncoder {
         // Preprocessing
         name = cleanName(name);
 
+        // Bulletproof if name becomes empty after cleanName(name)
+        if (SPACE.equals(name) || name.isEmpty()) {
+            return EMPTY;
+        }
+
         // BEGIN: Actual encoding part of the algorithm...
         // 1. Delete all vowels unless the vowel begins the word
         name = removeVowels(name);
+
+        // Bulletproof if name becomes empty after removeVowels(name)
+        if (SPACE.equals(name) || name.isEmpty()) {
+            return EMPTY;
+        }
 
         // 2. Remove second consonant from any double consonant
         name = removeDoubleConsonants(name);

--- a/src/test/java/org/apache/commons/codec/language/MatchRatingApproachEncoderTest.java
+++ b/src/test/java/org/apache/commons/codec/language/MatchRatingApproachEncoderTest.java
@@ -519,4 +519,18 @@ public class MatchRatingApproachEncoderTest extends AbstractStringEncoderTest<Ma
 
     // ***** END REGION - TEST GET MRA COMPARISONS
 
+    @Test
+    public final void testPunctuationOnly() {
+        assertEquals(this.getStringEncoder().encode(".,-"), "");
+    }
+
+    @Test
+    public final void testVowelOnly() {
+        assertEquals(this.getStringEncoder().encode("aeiouAEIOU"), "A");
+    }
+
+    @Test
+    public final void testVowelAndPunctuationOnly() {
+        assertEquals(this.getStringEncoder().encode("uoiea.,-AEIOU"), "U");
+    }
 }

--- a/src/test/java/org/apache/commons/codec/language/MatchRatingApproachEncoderTest.java
+++ b/src/test/java/org/apache/commons/codec/language/MatchRatingApproachEncoderTest.java
@@ -35,8 +35,6 @@ import org.junit.jupiter.api.Test;
  */
 public class MatchRatingApproachEncoderTest extends AbstractStringEncoderTest<MatchRatingApproachEncoder> {
 
-    // ********** BEGIN REGION - TEST SUPPORT METHODS
-
     @Override
     protected MatchRatingApproachEncoder createStringEncoder() {
         return new MatchRatingApproachEncoder();
@@ -248,10 +246,6 @@ public class MatchRatingApproachEncoderTest extends AbstractStringEncoderTest<Ma
         assertTrue(this.getStringEncoder().isEncodeEquals("O'Sullivan", "Ó ' Súilleabháin"));
     }
 
-    // ***** END REGION - TEST SUPPORT METHODS
-
-    // ***** BEGIN REGION - TEST GET MRA ENCODING
-
     @Test
     public final void testCompare_Surname_PRZEMYSL_PSHEMESHIL_SuccessfullyMatched() {
         assertTrue(this.getStringEncoder().isEncodeEquals(" P rz e m y s l", " P sh e m e sh i l"));
@@ -296,10 +290,6 @@ public class MatchRatingApproachEncoderTest extends AbstractStringEncoderTest<Ma
     public final void testCompare_ZACH_ZAKARIA_SuccessfullyMatched() {
         assertTrue(this.getStringEncoder().isEncodeEquals("Zach", "Zacharia"));
     }
-
-    // ***** END REGION - TEST GET MRA ENCODING
-
-    // ***** BEGIN REGION - TEST GET MRA COMPARISONS
 
     @Test
     public final void testCompareNameNullSpace_ReturnsFalseSuccessfully() {
@@ -433,8 +423,6 @@ public class MatchRatingApproachEncoderTest extends AbstractStringEncoderTest<Ma
         assertFalse(this.getStringEncoder().isEncodeEquals("", "test"));
     }
 
-    // **** BEGIN YIDDISH/SLAVIC SECTION ****
-
     @Test
     public final void testIsEncodeEquals_CornerCase_FirstNameNull_ReturnsFalse() {
         assertFalse(this.getStringEncoder().isEncodeEquals(null, "test"));
@@ -469,8 +457,6 @@ public class MatchRatingApproachEncoderTest extends AbstractStringEncoderTest<Ma
     public final void testIsVowel_SingleVowel_ReturnsTrue() {
         assertTrue(this.getStringEncoder().isVowel("I"));
     }
-
-    // **** END YIDDISH/SLAVIC SECTION ****
 
     @Test
     public final void testIsVowel_SmallD_ReturnsFalse() {


### PR DESCRIPTION
This fixes a possible StringIndexOutOfBoundException in [src/main/java/org/apache/commons/codec/language/MatchRatingApproachEncoder.java](https://github.com/apache/commons-codec/blob/master/src/main/java/org/apache/commons/codec/language/MatchRatingApproachEncoder.java) thrown by MatchRatingApproachEncoder.encode() method when the input string only contains punctuations or vowels.

This PR adds some conditional checking to ensure the string is not empty after each method call. If it is empty after any method call, it will simply return EMPTY and avoid continuing processing onto the next processing method.

We found this bug using fuzzing by way of OSS-Fuzz. It is reported at https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64359.