### PR TITLE
CODEC-313: Fix possible ArrayIndexOutOfBoundsException thrown by QuotedPrintableCodec.encodeQuotedPrintable() method

### DIFF
--- a/src/main/java/org/apache/commons/codec/net/QuotedPrintableCodec.java
+++ b/src/main/java/org/apache/commons/codec/net/QuotedPrintableCodec.java
@@ -85,6 +85,11 @@ public class QuotedPrintableCodec implements BinaryEncoder, BinaryDecoder, Strin
     private static final byte LF = 10;
 
     /**
+     * Minimum length required for the byte arrays used by encodeQuotedPrintable method
+     */
+    private static final int MIN_BYTES = 3;
+
+    /**
      * Safe line length for quoted printable encoded text.
      */
     private static final int SAFE_LENGTH = 73;
@@ -208,6 +213,10 @@ public class QuotedPrintableCodec implements BinaryEncoder, BinaryDecoder, Strin
         final int bytesLength = bytes.length;
 
         if (strict) {
+            if (bytesLength < MIN_BYTES) {
+                return null;
+            }
+
             int pos = 1;
             // encode up to buffer.length - 3, the last three octets will be treated
             // separately for simplification of note #3

--- a/src/test/java/org/apache/commons/codec/net/QuotedPrintableCodecTest.java
+++ b/src/test/java/org/apache/commons/codec/net/QuotedPrintableCodecTest.java
@@ -228,6 +228,12 @@ public class QuotedPrintableCodecTest {
     }
 
     @Test
+    public void testTooShortByteArray() throws Exception{
+        final QuotedPrintableCodec qpcodec = new QuotedPrintableCodec(true);
+        assertNull(qpcodec.encode("AA"), "Result should be null.");
+    }
+
+    @Test
     public void testTrailingSpecial() throws Exception {
         final QuotedPrintableCodec qpcodec = new QuotedPrintableCodec(true);
 


### PR DESCRIPTION
This fixes a possible ArrayIndexOutOfBoundException in [src/main/java/org/apache/commons/codec/language/QuotedPrintableCodec.java](https://github.com/apache/commons-codec/blob/master/src/main/java/org/apache/commons/codec/language/QuotedPrintableCodec.java) thrown by `QuotedPrintableCodec.encodeQuotedPrintable()` method when the input byte array has less than 3 elements.

This PR adds a conditional check to ensure the index is never negative. It will simply return null if the byte array is too short (with a length less than 3) if strict value is true.

We found this bug using fuzzing by way of OSS-Fuzz. It is reported at https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64358.