### PR TITLE
CODEC-314: Fix possible IndexOutOfBoundsException thrown by PercentCodec.insertAlwaysEncodeChars() method

### DIFF
--- a/src/main/java/org/apache/commons/codec/net/PercentCodec.java
+++ b/src/main/java/org/apache/commons/codec/net/PercentCodec.java
@@ -77,10 +77,15 @@ public class PercentCodec implements BinaryEncoder, BinaryDecoder {
      *
      * @param alwaysEncodeChars the unsafe characters that should always be encoded
      * @param plusForSpace      the flag defining if the space character should be encoded as '+'
+     * @throws EncoderException if the alwaysEncodeChars byte array contains invalid bytes
      */
-    public PercentCodec(final byte[] alwaysEncodeChars, final boolean plusForSpace) {
+    public PercentCodec(final byte[] alwaysEncodeChars, final boolean plusForSpace) throws EncoderException {
         this.plusForSpace = plusForSpace;
-        insertAlwaysEncodeChars(alwaysEncodeChars);
+        try {
+            insertAlwaysEncodeChars(alwaysEncodeChars);
+        } catch (IndexOutOfBoundsException e) {
+            throw new EncoderException(e);
+        }
     }
 
     private boolean canEncode(final byte c) {

--- a/src/test/java/org/apache/commons/codec/net/PercentCodecTest.java
+++ b/src/test/java/org/apache/commons/codec/net/PercentCodecTest.java
@@ -106,6 +106,13 @@ public class PercentCodecTest {
     }
 
     @Test
+    public void testInvalidByte() throws Exception {
+        final byte[] invalid = {(byte)-1, (byte)'A'};
+
+        assertThrows(EncoderException.class, () -> new PercentCodec(invalid, true));
+    }
+
+    @Test
     public void testPercentEncoderDecoderWithNullOrEmptyInput() throws Exception {
         final PercentCodec percentCodec = new PercentCodec(null, true);
         assertNull(percentCodec.encode(null), "Null input value encoding test");


### PR DESCRIPTION
This fixes a possible IndexOutOfBoundsException in [src/main/java/org/apache/commons/codec/net/PercentCodec.java](https://github.com/apache/commons-codec/blob/master/src/main/java/org/apache/commons/codec/net/PercentCodec.java) thrown by `PercentCodec.insertAlwaysEncodeChars()` method if the initial byte array contains negative bytes which are used as index for the BitSet.

This PR adds a conditional check to ensure only valid bytes (positive or zero) are processed.

We found this bug using fuzzing by way of OSS-Fuzz. It is reported at https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64362.