### PR TITLE
CODEC-315: Fix possible IndexOutOfBoundException thrown by PhoneticEngine.encode method

### DIFF
--- a/src/main/java/org/apache/commons/codec/language/bm/PhoneticEngine.java
+++ b/src/main/java/org/apache/commons/codec/language/bm/PhoneticEngine.java
@@ -409,7 +409,7 @@ public class PhoneticEngine {
         switch (this.nameType) {
         case SEPHARDIC:
             words.forEach(aWord -> {
-                final String[] parts = aWord.split("'");
+                final String[] parts = aWord.split("'", -1);
                 words2.add(parts[parts.length - 1]);
             });
             words2.removeAll(NAME_PREFIXES.get(this.nameType));
@@ -431,7 +431,7 @@ public class PhoneticEngine {
         } else if (words2.size() == 1) {
             // not a multi-word name
             input = words.iterator().next();
-        } else {
+        } else if (!words2.isEmpty()) {
             // encode each word in a multi-word name separately (normally used for approx matches)
             final StringBuilder result = new StringBuilder();
             words2.forEach(word -> result.append("-").append(encode(word)));

--- a/src/test/java/org/apache/commons/codec/language/bm/PhoneticEngineTest.java
+++ b/src/test/java/org/apache/commons/codec/language/bm/PhoneticEngineTest.java
@@ -48,6 +48,15 @@ public class PhoneticEngineTest {
                 );
     }
 
+    public static Stream<Arguments> invalidData() {
+        return Stream.of(
+                        Arguments.of("bar", "bar|bor|var|vor", NameType.ASHKENAZI, RuleType.APPROX, Boolean.FALSE, TEN),
+                        Arguments.of("al", "|al", NameType.SEPHARDIC, RuleType.APPROX, Boolean.FALSE, TEN),
+                        Arguments.of("da", "da|di", NameType.GENERIC, RuleType.EXACT, Boolean.FALSE, TEN),
+                        Arguments.of("'''", "", NameType.SEPHARDIC, RuleType.APPROX, Boolean.FALSE, TEN)
+                );
+    }
+
     // TODO Identify if there is a need to an assertTimeout(Duration.ofMillis(10000L) in some point, since this method was marked as @Test(timeout = 10000L)
     @ParameterizedTest
     @MethodSource("data")
@@ -69,5 +78,14 @@ public class PhoneticEngineTest {
                 assertTrue(split.length <= maxPhonemes);
             }
         }
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidData")
+    public void testInvalidEncode(final String input, final String phoneticExpected, final NameType nameType,
+                                  final RuleType ruleType, final boolean concat, final int maxPhonemes) {
+        final PhoneticEngine engine = new PhoneticEngine(nameType, ruleType, concat, maxPhonemes);
+
+        assertEquals(engine.encode(input), phoneticExpected);
     }
 }


### PR DESCRIPTION
This fixes possible StringIndexOutOfBoundsException and ArrayIndexOutOfBoundsException in [src/main/java/org/apache/commons/codec/language/bm/PhoneticEngine.java](https://github.com/apache/commons-codec/blob/master/src/main/java/org/apache/commons/codec/language/bm/PhoneticEngine.java) thrown by `PhoneticEngine.encode()` when the provided string only contains one of the name prefix of the chosen NameType or only contain single quotation character.

This PR fixes the parameter for the split method and adds a conditional check to ensure only strings and arrays are not empty before processing.

We found this bug using fuzzing by way of OSS-Fuzz. It is reported at https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64376 and https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64395.