### PR TITLE
modifying data size in DigestUtilsTest to speed up MessageDigestAlgor…

### DIFF
--- a/src/test/java/org/apache/commons/codec/digest/DigestUtilsTest.java
+++ b/src/test/java/org/apache/commons/codec/digest/DigestUtilsTest.java
@@ -56,7 +56,7 @@ public class DigestUtilsTest {
 
     private static final String EMPTY_STRING = "";
 
-    private final byte[] testData = new byte[1024 * 1024];
+    private final byte[] testData = new byte[32 * 32];
 
     private Path testFile;
 

--- a/src/test/java/org/apache/commons/codec/digest/DigestUtilsTest.java
+++ b/src/test/java/org/apache/commons/codec/digest/DigestUtilsTest.java
@@ -56,7 +56,7 @@ public class DigestUtilsTest {
 
     private static final String EMPTY_STRING = "";
 
-    private final byte[] testData = new byte[32 * 32];
+    private final byte[] testData = new byte[1024 * 4];
 
     private Path testFile;
 


### PR DESCRIPTION
The runtime of the test class `MessageDigestAlgorithmsTest` can be improved by modifying the data array size in `DigestUtilsTest`.

The byte array returned by `getTestData()` comes from DigestUtilsTest and has a size of `1024 * 1024`. When this array size is reduced to `32 * 32`, for example, the runtime of the `MessageDigestAlgorithmsTest` test class drops from `7.046 s` to `1.032 s` on our local machine. 

We propose not to make the tests in `MessageDigestAlgorithmsTest.java` rely on the data created by `DigestUtilsTest.java`.