### PR TITLE
Update Sha2Crypt.java

### DIFF
--- a/src/main/java/org/apache/commons/codec/digest/Sha2Crypt.java
+++ b/src/main/java/org/apache/commons/codec/digest/Sha2Crypt.java
@@ -69,7 +69,7 @@ public class Sha2Crypt {
 
     /** The pattern to match valid salt values. */
     private static final Pattern SALT_PATTERN = Pattern
-            .compile("^\\$([56])\\$(rounds=(\\d+)\\$)?([\\.\\/a-zA-Z0-9]{1,16}).*");
+            .compile("^\\$([56])\\$(rounds=(\\d+)\\$)?([\\.\\/a-zA-Z0-9]{1,16})$");
 
     /**
      * Generates a libc crypt() compatible "$5$" hash value with random salt.


### PR DESCRIPTION
The old regular expression is incorrect.
If you want to match [a-zA-Z0-9./] and limit the length to 16, I think it should be the following expression： "^\\$([56])\\$(rounds=(\\d+)\\$)?([\\.\\/a-zA-Z0-9]{1,16})$")