### PR TITLE
Simplify hex methods

### DIFF
--- a/src/main/java/org/apache/commons/codec/binary/Hex.java
+++ b/src/main/java/org/apache/commons/codec/binary/Hex.java
@@ -98,12 +98,10 @@ public class Hex implements BinaryEncoder, BinaryDecoder {
             throw new DecoderException("Output array is not large enough to accommodate decoded data.");
         }
         // two characters form the hex value.
-        for (int i = outOffset, j = 0; j < len; i++) {
-            int f = toDigit(data[j], j) << 4;
-            j++;
-            f |= toDigit(data[j], j);
-            j++;
-            out[i] = (byte) (f & 0xFF);
+        for (int i = 0, j = outOffset; i < len; i += 2, j++) {
+            final int high = toDigit(data[i], i) << 4;
+            final int low = toDigit(data[i + 1], i + 1);
+            out[j] = (byte) (high | low);
         }
         return outLen;
     }
@@ -207,9 +205,11 @@ public class Hex implements BinaryEncoder, BinaryDecoder {
      */
     private static char[] encodeHex(final byte[] data, final int dataOffset, final int dataLen, final char[] toDigits, final char[] out, final int outOffset) {
         // two characters form the hex value.
-        for (int i = dataOffset, j = outOffset; i < dataOffset + dataLen; i++) {
-            out[j++] = toDigits[(0xF0 & data[i]) >>> 4];
-            out[j++] = toDigits[0x0F & data[i]];
+        final int end = dataOffset + dataLen;
+        for (int i = dataOffset, j = outOffset; i < end; i++) {
+            final byte value = data[i];
+            out[j++] = toDigits[value >> 4 & 0x0f];
+            out[j++] = toDigits[value & 0x0f];
         }
         return out;
     }


### PR DESCRIPTION
Update methods encodeHex and decodeHex to simplify the code and make it slightly more efficient.

encodeHex: don't compute dataOffset + dataLen on every for iteration and also standardize nibble high and low using Base16.encode() as inspiration. I would say it's easier to read now.

decodeHex: get high and low nibble directly using for loop iterator incrementing by 2 (2 char per hex val) and OR them immediately instead of getting high nibble, iterating variable, ORing low nibble, iterating variable then converting to byte. I think it's far more readable this way.

I tested both with a barebones jmh benchmark and speed is roughly the same or very slightly faster than old implementation for both.