### PR TITLE
Use Resource.class to load resources, rather than its classloader

### DIFF
--- a/src/main/java/org/apache/commons/codec/Resources.java
+++ b/src/main/java/org/apache/commons/codec/Resources.java
@@ -33,7 +33,7 @@ public class Resources {
      * @return An input stream.
      */
     public static InputStream getInputStream(final String name) {
-        final InputStream inputStream = Resources.class.getClassLoader().getResourceAsStream(name);
+        final InputStream inputStream = Resources.class.getResourceAsStream(name);
         if (inputStream == null) {
             throw new IllegalArgumentException("Unable to resolve required resource: " + name);
         }

--- a/src/main/java/org/apache/commons/codec/language/DaitchMokotoffSoundex.java
+++ b/src/main/java/org/apache/commons/codec/language/DaitchMokotoffSoundex.java
@@ -212,7 +212,7 @@ public class DaitchMokotoffSoundex implements StringEncoder {
     private static final String MULTILINE_COMMENT_START = "/*";
 
     /** The resource file containing the replacement and folding rules */
-    private static final String RESOURCE_FILE = "org/apache/commons/codec/language/dmrules.txt";
+    private static final String RESOURCE_FILE = "/org/apache/commons/codec/language/dmrules.txt";
 
     /** The code length of a DM soundex value. */
     private static final int MAX_LENGTH = 6;

--- a/src/main/java/org/apache/commons/codec/language/bm/Lang.java
+++ b/src/main/java/org/apache/commons/codec/language/bm/Lang.java
@@ -101,7 +101,7 @@ public class Lang {
 
     private static final Map<NameType, Lang> LANGS = new EnumMap<>(NameType.class);
 
-    private static final String LANGUAGE_RULES_RN = "org/apache/commons/codec/language/bm/%s_lang.txt";
+    private static final String LANGUAGE_RULES_RN = "/org/apache/commons/codec/language/bm/%s_lang.txt";
 
     static {
         for (final NameType s : NameType.values()) {

--- a/src/main/java/org/apache/commons/codec/language/bm/Languages.java
+++ b/src/main/java/org/apache/commons/codec/language/bm/Languages.java
@@ -271,7 +271,7 @@ public class Languages {
     }
 
     private static String langResourceName(final NameType nameType) {
-        return String.format("org/apache/commons/codec/language/bm/%s_languages.txt", nameType.getName());
+        return String.format("/org/apache/commons/codec/language/bm/%s_languages.txt", nameType.getName());
     }
 
     private final Set<String> languages;

--- a/src/main/java/org/apache/commons/codec/language/bm/Rule.java
+++ b/src/main/java/org/apache/commons/codec/language/bm/Rule.java
@@ -265,7 +265,7 @@ public class Rule {
     }
 
     private static String createResourceName(final NameType nameType, final RuleType rt, final String lang) {
-        return String.format("org/apache/commons/codec/language/bm/%s_%s_%s.txt",
+        return String.format("/org/apache/commons/codec/language/bm/%s_%s_%s.txt",
                              nameType.getName(), rt.getName(), lang);
     }
 
@@ -277,7 +277,7 @@ public class Rule {
 
     @SuppressWarnings("resource") // Closing the Scanner closes the resource
     private static Scanner createScanner(final String lang) {
-        final String resName = String.format("org/apache/commons/codec/language/bm/%s.txt", lang);
+        final String resName = String.format("/org/apache/commons/codec/language/bm/%s.txt", lang);
         return new Scanner(Resources.getInputStream(resName), ResourceConstants.ENCODING);
     }
 

--- a/src/test/java/org/apache/commons/codec/ResourcesTest.java
+++ b/src/test/java/org/apache/commons/codec/ResourcesTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class ResourcesTest {
 
     static List<String> getResourceNames() {
-        return Arrays.asList("org/apache/commons/codec/language/dmrules.txt", "org/apache/commons/codec/language/bm/lang.txt");
+        return Arrays.asList("/org/apache/commons/codec/language/dmrules.txt", "/org/apache/commons/codec/language/bm/lang.txt");
     }
 
     @ParameterizedTest


### PR DESCRIPTION
This plays nicer with Java's module system, as the class is able to load files from within the current module, whereas the classloader may not necessarily be able to.

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible but is a best-practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that commits might be squashed by a maintainer on merge.
