### PR TITLE
[CODEC-338] Escape literal plus with plusForSpace

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -45,6 +45,7 @@ The <action> type attribute can be add,update,fix,remove.
   <body>
     <release version="1.22.1" date="YYYY-MM-DD" description="This is a feature and maintenance release. Java 8 or later is required.">
       <!-- FIX -->
+      <action type="fix" issue="CODEC-338" dev="ggregory" due-to="Ruiqi Dong, Gary Gregory">PercentCodec loses literal '+' when plusForSpace is enabled.</action>
       <action type="add" issue="CODEC-337" dev="pkarwasz" due-to="Ruiqi Dong, Gary Gregory">Digest ALL reuses System.in, so only the first algorithm sees the real input (#431).</action>
       <!-- ADD -->
       <!-- UPDATE -->

--- a/src/main/java/org/apache/commons/codec/net/PercentCodec.java
+++ b/src/main/java/org/apache/commons/codec/net/PercentCodec.java
@@ -45,6 +45,11 @@ public class PercentCodec implements BinaryEncoder, BinaryDecoder {
     private static final byte ESCAPE_CHAR = '%';
 
     /**
+     * The plus character used to encode spaces when plusForSpace is true.
+     */
+    private static final byte PLUS_CHAR = '+';
+
+    /**
      * The bit set used to store the character that should be always encoded.
      */
     private final BitSet alwaysEncodeChars = new BitSet();
@@ -80,6 +85,9 @@ public class PercentCodec implements BinaryEncoder, BinaryDecoder {
     public PercentCodec(final byte[] alwaysEncodeChars, final boolean plusForSpace) {
         this.plusForSpace = plusForSpace;
         insertAlwaysEncodeChars(alwaysEncodeChars);
+        if (plusForSpace) {
+            insertAlwaysEncodeChar(PLUS_CHAR);
+        }
     }
 
     private boolean canEncode(final byte c) {

--- a/src/test/java/org/apache/commons/codec/net/PercentCodecTest.java
+++ b/src/test/java/org/apache/commons/codec/net/PercentCodecTest.java
@@ -132,6 +132,28 @@ class PercentCodecTest {
     }
 
     @Test
+    void testPercentEncoderDecoderWithPlusForSpaceEscapesLiteralPlus() throws Exception {
+        final String input = "a+b c";
+        final PercentCodec percentCodec = new PercentCodec(null, true);
+        final byte[] encoded = percentCodec.encode(input.getBytes(StandardCharsets.UTF_8));
+        final String encodedS = new String(encoded, StandardCharsets.UTF_8);
+        assertEquals("a%2Bb+c", encodedS, "PercentCodec plus for space should escape literal plus");
+        final byte[] decode = percentCodec.decode(encoded);
+        assertEquals(new String(decode, StandardCharsets.UTF_8), input, "PercentCodec literal plus decoding test");
+    }
+
+    @Test
+    void testPercentEncoderDecoderWithPlusForSpaceEscapesLiteralPlusWithoutSpaces() throws Exception {
+        final String input = "a+b";
+        final PercentCodec percentCodec = new PercentCodec(null, true);
+        final byte[] encoded = percentCodec.encode(input.getBytes(StandardCharsets.UTF_8));
+        final String encodedS = new String(encoded, StandardCharsets.UTF_8);
+        assertEquals("a%2Bb", encodedS, "PercentCodec plus for space should escape literal plus without spaces");
+        final byte[] decode = percentCodec.decode(encoded);
+        assertEquals(new String(decode, StandardCharsets.UTF_8), input, "PercentCodec literal plus decoding test");
+    }
+
+    @Test
     void testSafeCharEncodeDecodeObject() throws Exception {
         final PercentCodec percentCodec = new PercentCodec(null, true);
         final String input = "abc123_-.*";


### PR DESCRIPTION
[[CODEC-338]](https://issues.apache.org/jira/browse/CODEC-338) PercentCodec loses literal '+' when plusForSpace is enabled.

This change makes `PercentCodec` percent-encode a literal `'+'` as `%2B` when `plusForSpace` is enabled. In that mode, decoding treats `'+'` as a space, so leaving a literal plus unescaped made the encoded output ambiguous and broke round-trip behavior.

The fix adds `'+'` to the always-encode character set when `plusForSpace` is `true`. Spaces are still encoded as `'+'`, while literal plus signs are preserved as `%2B`.

Tests added:
- `"a+b c"` encodes to `"a%2Bb+c"` and round-trips.
- `"a+b"` encodes to `"a%2Bb"` and round-trips, covering the no-space boundary case.

Also updates `src/changes/changes.xml` for CODEC-338.