### PR TITLE
[CODEC-339] Escape URLCodec control characters in custom safe sets

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -45,6 +45,7 @@ The <action> type attribute can be add,update,fix,remove.
   <body>
     <release version="1.22.1" date="YYYY-MM-DD" description="This is a feature and maintenance release. Java 8 or later is required.">
       <!-- FIX -->
+      <action type="fix" issue="CODEC-339" dev="ggregory" due-to="Ruiqi Dong, Gary Gregory">URLCodec.encodeUrl(BitSet, byte[]) allows custom safe sets to emit URL encoding control characters.</action>
       <action type="add" issue="CODEC-337" dev="pkarwasz" due-to="Ruiqi Dong, Gary Gregory">Digest ALL reuses System.in, so only the first algorithm sees the real input (#431).</action>
       <!-- ADD -->
       <!-- UPDATE -->

--- a/src/main/java/org/apache/commons/codec/net/URLCodec.java
+++ b/src/main/java/org/apache/commons/codec/net/URLCodec.java
@@ -53,6 +53,8 @@ public class URLCodec implements BinaryEncoder, BinaryDecoder, StringEncoder, St
      */
     protected static final byte ESCAPE_CHAR = '%';
 
+    private static final byte PLUS_CHAR = '+';
+
     /**
      * BitSet of www-form-url safe characters.
      * This is a copy of the internal BitSet which is now used for the conversion.
@@ -107,7 +109,7 @@ public class URLCodec implements BinaryEncoder, BinaryDecoder, StringEncoder, St
         final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         for (int i = 0; i < bytes.length; i++) {
             final int b = bytes[i];
-            if (b == '+') {
+            if (b == PLUS_CHAR) {
                 buffer.write(' ');
             } else if (b == ESCAPE_CHAR) {
                 try {
@@ -126,9 +128,11 @@ public class URLCodec implements BinaryEncoder, BinaryDecoder, StringEncoder, St
 
     /**
      * Encodes an array of bytes into an array of URL safe 7-bit characters. Unsafe characters are escaped.
+     * The characters {@code %} and {@code +} are always escaped because {@link #decodeUrl(byte[])}
+     * treats them as URL-encoding syntax.
      *
      * @param urlsafe
-     *            bitset of characters deemed URL safe.
+     *            bitset of characters deemed URL safe, except for {@code %} and {@code +}.
      * @param bytes
      *            array of bytes to convert to URL safe characters.
      * @return array of bytes containing URL safe characters.
@@ -147,9 +151,9 @@ public class URLCodec implements BinaryEncoder, BinaryDecoder, StringEncoder, St
             if (b < 0) {
                 b = 256 + b;
             }
-            if (urlsafe.get(b)) {
+            if (urlsafe.get(b) && b != ESCAPE_CHAR && b != PLUS_CHAR) {
                 if (b == ' ') {
-                    b = '+';
+                    b = PLUS_CHAR;
                 }
                 buffer.write(b);
             } else {

--- a/src/test/java/org/apache/commons/codec/net/URLCodecTest.java
+++ b/src/test/java/org/apache/commons/codec/net/URLCodecTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.charset.StandardCharsets;
+import java.util.BitSet;
 
 import org.apache.commons.codec.CharEncoding;
 import org.apache.commons.codec.DecoderException;
@@ -178,6 +179,30 @@ class URLCodecTest {
         assertEquals("Hello+there%21", encoded, "Basic URL encoding test");
         assertEquals(plain, urlCodec.decode(encoded), "Basic URL decoding test");
         validateState(urlCodec);
+    }
+
+    @Test
+    void testEncodeUrlWithPercentMarkedSafeEscapesPercent() throws Exception {
+        final BitSet safe = new BitSet();
+        safe.set('%');
+        final String plain = "%";
+        final byte[] encoded = URLCodec.encodeUrl(safe, plain.getBytes(StandardCharsets.US_ASCII));
+        final String encodedS = new String(encoded, StandardCharsets.US_ASCII);
+        assertEquals("%25", encodedS, "URLCodec should escape percent even when marked safe");
+        final byte[] decoded = URLCodec.decodeUrl(encoded);
+        assertEquals(plain, new String(decoded, StandardCharsets.US_ASCII), "URLCodec percent decoding test");
+    }
+
+    @Test
+    void testEncodeUrlWithPlusMarkedSafeEscapesPlus() throws Exception {
+        final BitSet safe = new BitSet();
+        safe.set('+');
+        final String plain = "+";
+        final byte[] encoded = URLCodec.encodeUrl(safe, plain.getBytes(StandardCharsets.US_ASCII));
+        final String encodedS = new String(encoded, StandardCharsets.US_ASCII);
+        assertEquals("%2B", encodedS, "URLCodec should escape plus even when marked safe");
+        final byte[] decoded = URLCodec.decodeUrl(encoded);
+        assertEquals(plain, new String(decoded, StandardCharsets.US_ASCII), "URLCodec plus decoding test");
     }
 
     @Test


### PR DESCRIPTION
[[CODEC-339]](https://issues.apache.org/jira/browse/CODEC-339) URLCodec custom safe sets can emit URL encoding control characters.

This change keeps `%` and `+` percent-encoded in `URLCodec.encodeUrl(BitSet, byte[])` even when a caller-provided safe-character `BitSet` marks them as safe.

`decodeUrl(byte[])` treats `%` as the escape prefix and `+` as a space. Allowing `encodeUrl(...)` to emit those bytes literally can produce undecodable output (`%`) or break round-trip behavior (`+` decodes as space). This patch preserves those characters as URL-encoding syntax and documents that they are always escaped.

Tests added:
- `%` marked safe still encodes as `%25` and decodes back to `%`.
- `+` marked safe still encodes as `%2B` and decodes back to `+`.

Also updates `src/changes/changes.xml` for CODEC-339.