### PR TITLE
[CODEC-343] Fix Base32 hex decode table builder

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -45,6 +45,7 @@ The <action> type attribute can be add,update,fix,remove.
   <body>
     <release version="1.22.1" date="YYYY-MM-DD" description="This is a feature and maintenance release. Java 8 or later is required.">
       <!-- FIX -->
+      <action type="fix" issue="CODEC-343" dev="ggregory" due-to="Ruiqi Dong, Gary Gregory">Base32.Builder.setHexDecodeTable(boolean) sets the encode table to a decode lookup table.</action>
       <action type="add" issue="CODEC-337" dev="pkarwasz" due-to="Ruiqi Dong, Gary Gregory">Digest ALL reuses System.in, so only the first algorithm sees the real input (#431).</action>
       <!-- ADD -->
       <!-- UPDATE -->

--- a/src/main/java/org/apache/commons/codec/binary/Base32.java
+++ b/src/main/java/org/apache/commons/codec/binary/Base32.java
@@ -103,7 +103,7 @@ public class Base32 extends BaseNCodec {
         }
 
         /**
-         * Sets the decode table to use Base32 hexadecimal if {@code true}, otherwise use the Base32 alphabet.
+         * Sets the encode and decode tables to use Base32 hexadecimal if {@code true}, otherwise use the Base32 alphabet.
          * <p>
          * This overrides a value previously set with {@link #setEncodeTable(byte...)}.
          * </p>
@@ -113,7 +113,7 @@ public class Base32 extends BaseNCodec {
          * @since 1.18.0
          */
         public Builder setHexDecodeTable(final boolean useHex) {
-            return setEncodeTable(decodeTable(useHex));
+            return setEncodeTable(encodeTable(useHex));
         }
 
         /**

--- a/src/test/java/org/apache/commons/codec/binary/Base32Test.java
+++ b/src/test/java/org/apache/commons/codec/binary/Base32Test.java
@@ -320,6 +320,15 @@ class Base32Test {
     }
 
     @Test
+    void testBuilderSetHexDecodeTableDecodesOwnOutput() {
+        final Base32 base32 = Base32.builder().setHexDecodeTable(true).setLineLength(0).get();
+        final byte[] data = { 0 };
+        final byte[] encoded = base32.encode(data);
+        assertEquals("00======", new String(encoded, StandardCharsets.US_ASCII));
+        assertArrayEquals(data, base32.decode(encoded));
+    }
+
+    @Test
     void testBase32HexSamples() throws Exception {
         final Base32 codec = new Base32(true);
         for (final String[] element : BASE32HEX_TEST_CASES) {


### PR DESCRIPTION
## Summary

Fix `Base32.Builder#setHexDecodeTable(boolean)` so it configures the matching Base32/Base32-Hex encode table instead of passing a decode lookup table to `setEncodeTable(byte...)`.

## Details

The previous implementation passed `decodeTable(useHex)` into `setEncodeTable(...)`. Used on its own, this made the codec encode with a decode lookup table and emit invalid bytes.

This change updates `setHexDecodeTable(boolean)` to use `encodeTable(useHex)` and adds a regression test proving the configured codec encodes with the Base32-Hex alphabet and decodes its own output.

## Tests

- `mvn -q -Dtest=org.apache.commons.codec.binary.Base32Test test`
- `mvn -q javadoc:javadoc`
- `mvn -q`