### PR TITLE
Size the buffer to the input for one-shot Base-N encode

### DIFF
--- a/src/main/java/org/apache/commons/codec/binary/BaseNCodec.java
+++ b/src/main/java/org/apache/commons/codec/binary/BaseNCodec.java
@@ -721,6 +721,15 @@ public abstract class BaseNCodec implements BinaryEncoder, BinaryDecoder {
             return array;
         }
         final Context context = new Context();
+        // Pre-size the buffer to the exact encoded length so a one-shot encode of a small input
+        // does not allocate the default streaming buffer (getDefaultBufferSize, 8192 bytes). The
+        // streaming path (via OutputStream) still grows from the default size. If the encoded length
+        // does not fit an int, fall back to the streaming buffer; such an output cannot be returned
+        // as a single array anyway.
+        final long encodedLength = getEncodedLength(length);
+        if (encodedLength <= Integer.MAX_VALUE) {
+            context.buffer = new byte[(int) encodedLength];
+        }
         encode(array, offset, length, context);
         encode(array, offset, EOF, context); // Notify encoder of EOF.
         final byte[] buf = new byte[context.pos - context.readPos];
@@ -822,9 +831,20 @@ public abstract class BaseNCodec implements BinaryEncoder, BinaryDecoder {
      * @return amount of space needed to encode the supplied array. Returns a long since a max-len array will require &gt; Integer.MAX_VALUE.
      */
     public long getEncodedLength(final byte[] array) {
+        return getEncodedLength(array.length);
+    }
+
+    /**
+     * Gets the amount of space needed to encode {@code inputLength} bytes.
+     *
+     * @param inputLength the number of bytes that will later be encoded.
+     * @return amount of space needed to encode the input. Returns a long since a max-len array will require
+     *         &gt; Integer.MAX_VALUE.
+     */
+    private long getEncodedLength(final int inputLength) {
         // Calculate non-chunked size - rounded up to allow for padding
         // cast to long is needed to avoid possibility of overflow
-        long len = (array.length + unencodedBlockSize - 1) / unencodedBlockSize * (long) encodedBlockSize;
+        long len = (inputLength + unencodedBlockSize - 1) / unencodedBlockSize * (long) encodedBlockSize;
         if (lineLength > 0) { // We're using chunking
             // Round up to nearest multiple
             len += (len + lineLength - 1) / lineLength * chunkSeparatorLength;


### PR DESCRIPTION
## Summary

`BaseNCodec.encode(byte[], int, int)` — which backs `encode(byte[])`, `encodeToString` and the static `Base64`/`Base32` helpers — created a `Context` whose buffer was lazily allocated by `ensureBufferSize` at `max(size, 8192)`. For a one-shot encode of a small input this allocated the full **8192-byte default streaming buffer** regardless of the actual output size.

The exact output size is already computable via `getEncodedLength`, so this pre-sizes the context buffer to it before encoding. The streaming path (`Base64OutputStream` etc.) is unchanged and still grows from the default size. When the encoded length does not fit an `int` the code falls back to the streaming buffer (such an output cannot be returned as a single array anyway). `getEncodedLength(byte[])` is refactored to delegate to a private length-based helper so the one-shot encode can size from the requested range length.

## Measurement

ThreadMXBean allocation driver, 200k warmed ops, 25-byte input:

| call | before | after |
|------|--------|-------|
| `Base64.encodeToString` | 8479 B/op | 345 B/op (−96%) |
| `Base32.encodeToString` | 8592 B/op | 458 B/op (−95%) |

## Testing

`Base64Test`, `Base32Test`, `Base16Test`, `BaseNCodecTest` and the Base64 input/output stream tests pass unchanged (360 tests). The streaming buffer growth path is exercised by the existing stream tests.
